### PR TITLE
#41312 first config property (sync enabled/disabled) can be manipulat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 Java.gitignore
 build/
 bin/
+.kotlin/

--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ client:
     tenant-id: swisscom-health-tenant-id # provided by Swisscom Health
     client-id: my-client-id # Self-service on CDR website
     client-secret: my-secret # Self-service on CDR website
-    renew-credential-at-startup: false
+    renew-credential: false
+    max-credential-age: 365d
+    last-credential-renewal-time: 2025-06-05T14:01:42Z
   cdr-api:
     host: cdr.health.swisscom.ch
   retry-delay: 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,22 +1,59 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import org.gradle.kotlin.dsl.withType
+
 allprojects {
     version = "3.4.2-SNAPSHOT"
 }
 
 plugins {
-    // this is necessary to avoid the plugins to be loaded multiple times
-    // in each subproject's classloader
+    // this is necessary to avoid the plugins to be loaded multiple times in each subproject's classloader
     alias(libs.plugins.jetbrains.compose) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.docker.compose) apply false
     alias(libs.plugins.spring.boot) apply false
     alias(libs.plugins.spring.dependency.management) apply false
-    alias(libs.plugins.detekt) apply false
     kotlin("jvm").version(libs.versions.kotlin.lang) apply false
     kotlin("plugin.spring").version(libs.versions.kotlin.lang) apply false
     // https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.kotlin.configuration-properties
     // KAPT is end of life, but KSP is not supported yet: https://github.com/spring-projects/spring-boot/issues/28046
     kotlin("kapt").version(libs.versions.kotlin.lang) apply false
+
+    // but we actually want to run detekt in all subprojects
+    alias(libs.plugins.detekt)
+}
+
+subprojects {
+    apply {
+        plugin("io.gitlab.arturbosch.detekt")
+    }
+
+    detekt {
+        config.from(rootProject.files("config/detekt.yml"))
+        buildUponDefaultConfig = false // preconfigure defaults
+        allRules = true
+        parallel = true
+    }
+
+    tasks.withType<Detekt> {
+        reports {
+            xml.required.set(true)
+            html.required.set(false)
+            sarif.required.set(false)
+            txt.required.set(false)
+        }
+    }
+
+    project.afterEvaluate {
+        // https://github.com/detekt/detekt/issues/6198#issuecomment-2265183695
+        configurations.matching { it.name == "detekt" }.all {
+            resolutionStrategy.eachDependency {
+                if (requested.group == "org.jetbrains.kotlin") {
+                    useVersion(io.gitlab.arturbosch.detekt.getSupportedKotlinVersion())
+                }
+            }
+        }
+    }
 }
 
 // NOTE: you should to run this target or manually update `gradle/gradle-daemon-jvm.properties` if we change the Java version!

--- a/cdr-client-common/build.gradle.kts
+++ b/cdr-client-common/build.gradle.kts
@@ -1,7 +1,6 @@
 group = "com.swisscom.health.des.cdr.client.common"
 
 plugins {
-    alias(libs.plugins.detekt)
     kotlin("jvm").version(libs.versions.kotlin.lang)
     alias(libs.plugins.kotlinx.serialization)
     `maven-publish`
@@ -16,17 +15,6 @@ idea {
     module {
         isDownloadJavadoc = true
         isDownloadSources = true
-    }
-}
-
-project.afterEvaluate {
-    // https://github.com/detekt/detekt/issues/6198#issuecomment-2265183695
-    configurations.matching { it.name == "detekt" }.all {
-        resolutionStrategy.eachDependency {
-            if (requested.group == "org.jetbrains.kotlin") {
-                useVersion(io.gitlab.arturbosch.detekt.getSupportedKotlinVersion())
-            }
-        }
     }
 }
 

--- a/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/Constants.kt
+++ b/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/Constants.kt
@@ -1,0 +1,13 @@
+package com.swisscom.health.des.cdr.client.common
+
+import java.time.Duration
+
+object Constants {
+    const val SHUTDOWN_DELAY_MILLIS: Long = 250
+
+    @JvmStatic
+    val SHUTDOWN_DELAY: Duration = Duration.ofMillis(SHUTDOWN_DELAY_MILLIS)
+
+    const val CONFIG_CHANGE_EXIT_CODE = 29
+    const val UNKNOWN_EXIT_CODE = 31
+}

--- a/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/DTOs.kt
+++ b/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/DTOs.kt
@@ -1,22 +1,53 @@
-@file:UseSerializers(InstantSerializer::class)
+@file:UseSerializers(InstantSerializer::class, DurationSerializer::class, UrlSerializer::class, NioPathSerializer::class)
 
 package com.swisscom.health.des.cdr.client.common
 
-import kotlinx.serialization.Serializable
-import java.time.Instant
-
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import java.net.URI
+import java.net.URL
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
 
 object InstantSerializer : KSerializer<Instant> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("java.time.Instant", PrimitiveKind.STRING)
     override fun serialize(encoder: Encoder, value: Instant) = encoder.encodeString(value.toString())
     override fun deserialize(decoder: Decoder): Instant = Instant.parse(decoder.decodeString())
+}
+
+object DurationSerializer : KSerializer<Duration> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("java.time.Duration", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: Duration) = encoder.encodeString(value.toString())
+    override fun deserialize(decoder: Decoder): Duration = Duration.parse(decoder.decodeString())
+}
+
+object UrlSerializer : KSerializer<URL> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("java.net.URL", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: URL) = encoder.encodeString(value.toString())
+    override fun deserialize(decoder: Decoder): URL = URL(decoder.decodeString())
+}
+
+// Need to be compatible with `com.fasterxml.jackson.databind.ext.NioPathSerializer.serialize` where a java.nio.file.Path is serialized as a URI string.
+object NioPathSerializer : KSerializer<Path> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("java.nio.file.Path", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: Path) = encoder.encodeString(value.toUri().toString())
+    override fun deserialize(decoder: Decoder): Path = decoder.decodeString()
+        .run {
+            runCatching {
+                // Try to parse as a URI first, as this is how Jackson serializes it.
+                Path.of(URI(this))
+            }
+                .recoverCatching {
+                    Path.of(this)
+                }.getOrThrow()
+        }
 }
 
 class DTOs {
@@ -48,5 +79,152 @@ class DTOs {
         val trigger: String,
         val exitCode: Int,
     )
+
+    /**
+     * CDR client configuration class hierarchy. It is an almost verbatim copy of `com.swisscom.health.des.cdr.client.config.CdrClientConfig`.
+     *
+     * NOTE: Deserialization with Jackson fails if constructor parameters don't have default values.
+     */
+    @Serializable
+    data class CdrClientConfig(
+        val fileSynchronizationEnabled: Boolean,
+        val customer: List<Connector>,
+        val cdrApi: Endpoint,
+        val filesInProgressCacheSize: String,
+        val idpCredentials: IdpCredentials,
+        val idpEndpoint: URL,
+        val localFolder: Path,
+        val pullThreadPoolSize: Int,
+        val pushThreadPoolSize: Int,
+        val retryDelay: List<Duration>,
+        val scheduleDelay: Duration,
+        val credentialApi: Endpoint,
+        val fileBusyTestInterval: Duration,
+        val fileBusyTestTimeout: Duration,
+        val fileBusyTestStrategy: FileBusyTestStrategy,
+    ) {
+
+        companion object {
+            @JvmStatic
+            val EMPTY = CdrClientConfig(
+                fileSynchronizationEnabled = false,
+                customer = emptyList(),
+                cdrApi = Endpoint.EMPTY,
+                filesInProgressCacheSize = "",
+                idpCredentials = IdpCredentials.EMPTY,
+                idpEndpoint = URL("http://localhost:8080"),
+                localFolder = EMPTY_PATH,
+                pullThreadPoolSize = 0,
+                pushThreadPoolSize = 0,
+                retryDelay = emptyList(),
+                scheduleDelay = Duration.ZERO,
+                credentialApi = Endpoint.EMPTY,
+                fileBusyTestInterval = Duration.ZERO,
+                fileBusyTestTimeout = Duration.ZERO,
+                fileBusyTestStrategy = FileBusyTestStrategy.NEVER_BUSY
+            )
+        }
+
+        @Serializable
+        data class Connector(
+            val connectorId: String,
+            val targetFolder: Path,
+            val sourceFolder: Path,
+            val contentType: String,
+            val sourceArchiveEnabled: Boolean,
+            val sourceArchiveFolder: Path,
+            val sourceErrorFolder: Path,
+            val mode: Mode,
+            val docTypeFolders: Map<DocumentType, DocTypeFolders>,
+        ) {
+
+            @Serializable
+            data class DocTypeFolders(
+                val sourceFolder: Path? = null,
+                val targetFolder: Path,
+            )
+
+        }
+
+        @Serializable
+        data class Endpoint(
+            val scheme: String,
+            val host: String,
+            val port: Int,
+            val basePath: String,
+        ) {
+            companion object {
+                @JvmStatic
+                val EMPTY = Endpoint(
+                    scheme = "",
+                    host = "",
+                    port = 0,
+                    basePath = ""
+                )
+            }
+        }
+
+        @Serializable
+        data class IdpCredentials(
+            val tenantId: String,
+            val clientId: String,
+            val clientSecret: String,
+            val scopes: List<String>,
+            val renewCredential: Boolean,
+            val maxCredentialAge: Duration,
+            val lastCredentialRenewalTime: Instant,
+        ) {
+            companion object {
+                @JvmStatic
+                val EMPTY = IdpCredentials(
+                    tenantId = "",
+                    clientId = "",
+                    clientSecret = "",
+                    scopes = emptyList(),
+                    renewCredential = false,
+                    maxCredentialAge = Duration.ZERO,
+                    lastCredentialRenewalTime = Instant.EPOCH
+                )
+            }
+        }
+
+        enum class DocumentType {
+            UNDEFINED,
+            CONTAINER,
+            CREDIT,
+            FORM,
+            HOSPITAL_MCD,
+            INVOICE,
+            NOTIFICATION;
+        }
+
+        enum class Mode {
+            TEST,
+            PRODUCTION,
+            NONE
+        }
+
+        enum class FileBusyTestStrategy {
+            /** checks for file size changes over a configurable duration.  */
+            FILE_SIZE_CHANGED,
+
+            /**
+             * always flags the file as 'not busy'; use if all downstream applications
+             * create files in a single atomic operation (`move` on the same file system).
+             */
+            NEVER_BUSY,
+
+            /** always flags the file as 'busy'; only useful for test scenarios. */
+            ALWAYS_BUSY,
+        }
+
+    }
+
+    companion object {
+
+        @JvmStatic
+        val EMPTY_PATH: Path = Path.of("")
+
+    }
 
 }

--- a/cdr-client-service/build.gradle.kts
+++ b/cdr-client-service/build.gradle.kts
@@ -1,4 +1,3 @@
-import io.gitlab.arturbosch.detekt.Detekt
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 import java.net.URI
 import java.time.Duration
@@ -11,7 +10,6 @@ plugins {
     alias(libs.plugins.docker.compose)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
-    alias(libs.plugins.detekt)
     jacoco
     application
     kotlin("jvm").version(libs.versions.kotlin.lang)
@@ -61,17 +59,6 @@ gradle.taskGraph.whenReady(
     }
 )
 
-project.afterEvaluate {
-    // https://github.com/detekt/detekt/issues/6198#issuecomment-2265183695
-    configurations.matching { it.name == "detekt" }.all {
-        resolutionStrategy.eachDependency {
-            if (requested.group == "org.jetbrains.kotlin") {
-                useVersion(io.gitlab.arturbosch.detekt.getSupportedKotlinVersion())
-            }
-        }
-    }
-}
-
 dependencies {
     implementation(platform(libs.spring.boot.dependencies))
     implementation(platform(libs.spring.cloud.dependencies))
@@ -90,8 +77,8 @@ dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.webflux)
     implementation(libs.spring.retry)
-    implementation(libs.spring.cloud.context)
     implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jackson.module.kotlin)
     implementation(projects.cdrClientCommon)
 
     // Note: At the time of writing the configuration processor seems to be broken; might be related to the upgrade to Kotlin 2.x
@@ -158,7 +145,7 @@ val jacocoTestCoverageVerification = tasks.named<JacocoCoverageVerification>("ja
                 }
             }))
             limit {
-                minimum = "0.70".toBigDecimal()
+                minimum = "0.68".toBigDecimal()
             }
         }
     }
@@ -211,29 +198,6 @@ tasks.processResources {
     filesMatching("**/application.yaml") {
         expand(project.properties)
     }
-}
-
-tasks.withType<Detekt> {
-    reports {
-        xml {
-            required.set(true)
-            outputLocation.set(File("${outputDir.get().asFile.absolutePath}/reports/detekt.xml"))
-        }
-        html.required.set(false)
-        sarif.required.set(false)
-        txt.required.set(false)
-    }
-}
-
-/**
- * Detekt
- * See https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-gradle/
- */
-detekt {
-    buildUponDefaultConfig = false // preconfigure defaults
-    allRules = true
-    parallel = true
-    config.setFrom(files("$rootDir/config/detekt.yml")) // Global Detekt rule set.
 }
 
 tasks.register("publishVersion") {

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/CdrClientApplication.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/CdrClientApplication.kt
@@ -18,7 +18,7 @@ internal const val CONFIG_FILE = "application-customer.properties"
 @SpringBootApplication(exclude = [ScheduledTasksObservabilityAutoConfiguration::class])
 @EnableConfigurationProperties(CdrClientConfig::class)
 @EnableScheduling
-class CdrClientApplication
+internal class CdrClientApplication
 
 @Suppress("SpreadOperator")
 fun main(args: Array<String>) {

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/config/ConfigConverter.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/config/ConfigConverter.kt
@@ -1,0 +1,162 @@
+package com.swisscom.health.des.cdr.client.config
+
+import com.swisscom.health.des.cdr.client.common.DTOs
+import com.swisscom.health.des.cdr.client.config.CdrClientConfig.RetryTemplateConfig
+import com.swisscom.health.des.cdr.client.xml.DocumentType
+import org.springframework.http.MediaType
+import org.springframework.util.unit.DataSize
+
+/*
+ * BEGIN - Spring Configuration -> Configuration DTOs
+ */
+internal fun CdrClientConfig.toDto(): DTOs.CdrClientConfig {
+    fun List<CdrClientConfig.Connector>.toDto(): List<DTOs.CdrClientConfig.Connector> = map { it.toDto() }
+    fun CdrClientConfig.FileBusyTestStrategy.toDto(): DTOs.CdrClientConfig.FileBusyTestStrategy =
+        DTOs.CdrClientConfig.FileBusyTestStrategy.entries.first { it.name == name }
+
+    return DTOs.CdrClientConfig(
+        fileSynchronizationEnabled = fileSynchronizationEnabled.value,
+        customer = customer.toDto(),
+        cdrApi = cdrApi.toDto(),
+        filesInProgressCacheSize = filesInProgressCacheSize.toString(),
+        idpCredentials = idpCredentials.toDto(),
+        idpEndpoint = idpEndpoint,
+        localFolder = localFolder,
+        pullThreadPoolSize = pullThreadPoolSize,
+        pushThreadPoolSize = pushThreadPoolSize,
+        retryDelay = retryDelay,
+        scheduleDelay = scheduleDelay,
+        credentialApi = credentialApi.toDto(),
+        fileBusyTestInterval = fileBusyTestInterval,
+        fileBusyTestTimeout = fileBusyTestTimeout,
+        fileBusyTestStrategy = fileBusyTestStrategy.toDto(),
+    )
+}
+
+internal fun CdrClientConfig.Connector.toDto(): DTOs.CdrClientConfig.Connector {
+    fun Map<DocumentType, CdrClientConfig.Connector.DocTypeFolders>.toDto():
+            Map<DTOs.CdrClientConfig.DocumentType, DTOs.CdrClientConfig.Connector.DocTypeFolders> {
+        return map { (key, value) ->
+            DTOs.CdrClientConfig.DocumentType.entries.first { it.name == key.name } to DTOs.CdrClientConfig.Connector.DocTypeFolders(
+                sourceFolder = value.sourceFolder,
+                targetFolder = value.targetFolder
+            )
+        }.toMap()
+    }
+
+    return DTOs.CdrClientConfig.Connector(
+        connectorId = connectorId,
+        targetFolder = targetFolder,
+        sourceFolder = sourceFolder,
+        contentType = contentType.toString(),
+        sourceArchiveEnabled = sourceArchiveEnabled,
+        sourceArchiveFolder = sourceArchiveFolder,
+        sourceErrorFolder = sourceErrorFolder,
+        mode = DTOs.CdrClientConfig.Mode.entries.first { it.name == mode.name },
+        docTypeFolders = docTypeFolders.toDto(),
+    )
+}
+
+internal fun CdrClientConfig.Endpoint.toDto(): DTOs.CdrClientConfig.Endpoint =
+    DTOs.CdrClientConfig.Endpoint(
+        scheme = scheme,
+        host = host,
+        port = port,
+        basePath = basePath
+    )
+
+internal fun IdpCredentials.toDto(): DTOs.CdrClientConfig.IdpCredentials =
+    DTOs.CdrClientConfig.IdpCredentials(
+        tenantId = tenantId,
+        clientId = clientId,
+        clientSecret = clientSecret.value,
+        scopes = scopes,
+        renewCredential = renewCredential.value,
+        maxCredentialAge = maxCredentialAge,
+        lastCredentialRenewalTime = lastCredentialRenewalTime.value,
+    )
+/*
+ * END - Spring Configuration -> Configuration DTOs
+ */
+
+/*
+ * BEGIN - Configuration DTOs -> Spring Configuration
+ */
+internal fun DTOs.CdrClientConfig.toCdrClientConfig(): CdrClientConfig {
+    fun List<DTOs.CdrClientConfig.Connector>.toCdrClientConfig(): List<CdrClientConfig.Connector> = map { it.toCdrClientConfig() }
+    fun DTOs.CdrClientConfig.FileBusyTestStrategy.toCdrClientConfig(): CdrClientConfig.FileBusyTestStrategy =
+        CdrClientConfig.FileBusyTestStrategy.valueOf(name)
+
+    val defaultRetryTemplateConfig = RetryTemplateConfig(
+        retries = 0,
+        initialDelay = java.time.Duration.ZERO,
+        maxDelay = java.time.Duration.ZERO,
+        multiplier = 0.0
+    )
+
+    return CdrClientConfig(
+        fileSynchronizationEnabled = if (fileSynchronizationEnabled) FileSynchronization.ENABLED else FileSynchronization.DISABLED,
+        customer = customer.toCdrClientConfig(),
+        cdrApi = cdrApi.toCdrClientConfig(),
+        filesInProgressCacheSize = DataSize.parse(filesInProgressCacheSize),
+        idpCredentials = idpCredentials.toCdrClientConfig(),
+        idpEndpoint = idpEndpoint,
+        localFolder = localFolder,
+        pullThreadPoolSize = pullThreadPoolSize,
+        pushThreadPoolSize = pushThreadPoolSize,
+        retryDelay = retryDelay,
+        scheduleDelay = scheduleDelay,
+        credentialApi = credentialApi.toCdrClientConfig(),
+        fileBusyTestInterval = fileBusyTestInterval,
+        fileBusyTestTimeout = fileBusyTestTimeout,
+        fileBusyTestStrategy = fileBusyTestStrategy.toCdrClientConfig(),
+        retryTemplate = defaultRetryTemplateConfig,
+    )
+}
+
+internal fun DTOs.CdrClientConfig.Connector.toCdrClientConfig(): CdrClientConfig.Connector {
+    fun Map<DTOs.CdrClientConfig.DocumentType, DTOs.CdrClientConfig.Connector.DocTypeFolders>.toCdrClientConfig():
+            Map<DocumentType, CdrClientConfig.Connector.DocTypeFolders> {
+        return map { (key, value) ->
+            DocumentType.valueOf(key.name) to CdrClientConfig.Connector.DocTypeFolders(
+                sourceFolder = value.sourceFolder,
+                targetFolder = value.targetFolder
+            )
+        }.toMap()
+    }
+
+    return CdrClientConfig.Connector(
+        connectorId = connectorId,
+        targetFolder = targetFolder,
+        sourceFolder = sourceFolder,
+        contentType = MediaType.parseMediaType(contentType),
+        sourceArchiveEnabled = sourceArchiveEnabled,
+        sourceArchiveFolder = sourceArchiveFolder,
+        sourceErrorFolder = sourceErrorFolder,
+        mode = CdrClientConfig.Mode.valueOf(mode.name),
+        docTypeFolders = docTypeFolders.toCdrClientConfig(),
+    )
+}
+
+internal fun DTOs.CdrClientConfig.Endpoint.toCdrClientConfig(): CdrClientConfig.Endpoint =
+    CdrClientConfig.Endpoint(
+        scheme = scheme,
+        host = host,
+        port = port,
+        basePath = basePath
+    )
+
+internal fun DTOs.CdrClientConfig.IdpCredentials.toCdrClientConfig(): IdpCredentials =
+    IdpCredentials(
+        tenantId = tenantId,
+        clientId = clientId,
+        clientSecret = ClientSecret(clientSecret),
+        scopes = scopes,
+        renewCredential = RenewCredential(renewCredential),
+        maxCredentialAge = maxCredentialAge,
+        lastCredentialRenewalTime = LastUpdatedAt(lastCredentialRenewalTime),
+    )
+
+/*
+ * END - Configuration DTOs -> Spring Configuration
+ */

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/CdrApiClient.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/CdrApiClient.kt
@@ -34,7 +34,7 @@ private val logger = KotlinLogging.logger {}
 
 @Suppress("TooManyFunctions")
 @Service
-class CdrApiClient(
+internal class CdrApiClient(
     private val cdrClientConfig: CdrClientConfig,
     private val httpClient: OkHttpClient,
     private val clientCredentialParams: ClientCredentialParameters,
@@ -71,7 +71,7 @@ class CdrApiClient(
                             this.build()
                         }
                     )
-                    // unfortunately okHttp requires a non-null body for patch/post requests
+                    // unfortunately, okHttp requires a non-null body for patch/post requests
                     // https://github.com/square/okhttp/issues/7005
                     .patch(byteArrayOf().toRequestBody())
                     .build()
@@ -444,23 +444,23 @@ class CdrApiClient(
         val EMPTY_PATH: Path = Path.of("")
     }
 
-    sealed class DownloadDocumentResult {
-        object NoDocumentPending : DownloadDocumentResult()
-        data class Success(val pullResultId: String, val file: Path = EMPTY_PATH) : DownloadDocumentResult()
-        data class DownloadError(val code: Int? = null, val message: String, val t: Throwable? = null) : DownloadDocumentResult()
+    sealed interface DownloadDocumentResult {
+        object NoDocumentPending : DownloadDocumentResult
+        data class Success(val pullResultId: String, val file: Path = EMPTY_PATH) : DownloadDocumentResult
+        data class DownloadError(val code: Int? = null, val message: String, val t: Throwable? = null) : DownloadDocumentResult
     }
 
-    sealed class UploadDocumentResult {
-        object Success : UploadDocumentResult()
-        data class UploadClientErrorResponse(val code: Int, val responseBody: String) : UploadDocumentResult()
-        data class UploadServerErrorResponse(val code: Int, val responseBody: String) : UploadDocumentResult()
-        data class UploadError(val message: String, val t: Throwable? = null) : UploadDocumentResult()
+    sealed interface UploadDocumentResult {
+        object Success : UploadDocumentResult
+        data class UploadClientErrorResponse(val code: Int, val responseBody: String) : UploadDocumentResult
+        data class UploadServerErrorResponse(val code: Int, val responseBody: String) : UploadDocumentResult
+        data class UploadError(val message: String, val t: Throwable? = null) : UploadDocumentResult
     }
 
-    sealed class RenewClientSecretResult {
-        data class Success(val clientId: String, val clientSecret: String) : RenewClientSecretResult()
-        data class RenewHttpErrorResponse(val code: Int, val responseBody: String) : RenewClientSecretResult()
-        data class RenewError(val message: String, val cause: Throwable) : RenewClientSecretResult()
+    sealed interface RenewClientSecretResult {
+        data class Success(val clientId: String, val clientSecret: String) : RenewClientSecretResult
+        data class RenewHttpErrorResponse(val code: Int, val responseBody: String) : RenewClientSecretResult
+        data class RenewError(val message: String, val cause: Throwable) : RenewClientSecretResult
 
     }
 

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ClientSecretRenewalService.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ClientSecretRenewalService.kt
@@ -1,116 +1,80 @@
 package com.swisscom.health.des.cdr.client.handler
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.swisscom.health.des.cdr.client.config.CdrClientConfig
+import com.swisscom.health.des.cdr.client.config.ClientSecret
+import com.swisscom.health.des.cdr.client.config.LastUpdatedAt
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.tracing.Tracer
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.origin.Origin
-import org.springframework.boot.origin.OriginLookup
-import org.springframework.boot.origin.PropertySourceOrigin
-import org.springframework.boot.origin.TextResourceOrigin
-import org.springframework.context.ConfigurableApplicationContext
-import org.springframework.core.io.FileSystemResource
-import org.springframework.core.io.Resource
-import org.springframework.core.io.WritableResource
 import org.springframework.stereotype.Service
-import java.util.Properties
+import java.time.Instant
+
+private val logger = KotlinLogging.logger {}
 
 @Service
-@ConditionalOnProperty(prefix = "client.idp-credentials", name = ["renew-credential-at-startup"], havingValue = "true")
-class ClientSecretRenewalService(
-    private val context: ConfigurableApplicationContext,
+@ConditionalOnProperty(prefix = "client.idp-credentials", name = ["renew-credential"], havingValue = "true")
+internal class ClientSecretRenewalService(
+    private val config: CdrClientConfig,
+    private val configurationWriter: ConfigurationWriter,
     private val cdrApiClient: CdrApiClient,
     private val tracer: Tracer
 ) {
+    sealed interface RenewClientSecretResult {
+        object Success : RenewClientSecretResult
+        object Failure : RenewClientSecretResult
+    }
 
     fun renewClientSecret(): RenewClientSecretResult =
         runCatching {
-            findSecretOrigin()
-        }.mapCatching { origin ->
-            origin.fileBackedResource
-        }.mapCatching { resource: Resource ->
-            resource.writeableResource
-        }.mapCatching { writeableResource: WritableResource ->
-            // make API call lazy so it only happens after it is confirmed that the text origin is either a yaml or properties file
-            val clientSecret: String by lazy(LazyThreadSafetyMode.NONE) { getNewSecret() }
+            val secretIsWritable = ensureConfigItemIsWritable(CLIENT_SECRET_PROPERTY_PATH)
+            val timestampIsWritable = ensureConfigItemIsWritable(CLIENT_SECRET_LAST_UPDATE_PROPERTY_PATH)
 
-            when (writeableResource.fileTypeFromExtension) {
-                FileType.YAML -> updateYamlSource(writeableResource, clientSecret)
-                FileType.PROPERTIES -> updatePropertySource(writeableResource, clientSecret)
+            if (secretIsWritable && timestampIsWritable) {
+                writeNewSecret(getNewSecret())
+            } else {
+                RenewClientSecretResult.Failure
             }
-            writeableResource
         }.fold(
-            onSuccess = { updatedResource: WritableResource -> RenewClientSecretResult.Success(updatedResource) },
-            onFailure = { error: Throwable -> RenewClientSecretResult.RenewError(error) }
+            onSuccess = { it },
+            onFailure = { error: Throwable ->
+                RenewClientSecretResult.Failure.also {
+                    logger.error(error) { "Exception while trying to renew secret: $error" }
+                }
+            }
         )
 
-    /**
-     * Currently it is not possible to determine the "effective origin" of a property value based on the precedence rules
-     * for property sources in SpringBoot. But it might be in the future: [ticket](https://github.com/spring-projects/spring-boot/issues/21613)
-     *
-     * As we cannot determine the effective origin and then check whether it is an updatable text resource we search all
-     * available property sources for the client secret property and fail if we find more than one origin or none at all.
-     */
-    private fun findSecretOrigin(): Origin {
-        @Suppress("UNCHECKED_CAST")
-        val clientCredentialOrigins = context.environment.propertySources
-            // at the time of writing there exist only OriginLookup<String> implementations on the classpath
-            .mapNotNull { if (it is OriginLookup<*>) it as OriginLookup<String> else null }
-            .mapNotNull { it.getOrigin(CLIENT_SECRET_PROPERTY_PATH) }
-            // if configuration files are added via the `spring.config.additional-local` property, then a property from an additional,
-            // location ends up in two origins, a property source origin that encapsulates the actual origin, and that origin directly.
-            .map { if (it is PropertySourceOrigin) it.origin else it }
-            .toSet()
+    private fun ensureConfigItemIsWritable(property: String): Boolean =
+        when (configurationWriter.isWritableConfigurationItem(property)) {
+            is ConfigurationWriter.ConfigLookupResult.Writable -> true
 
-        when {
-            clientCredentialOrigins.isEmpty() ->
-                error("No origin found for client secret `$CLIENT_SECRET_PROPERTY_PATH`")
+            ConfigurationWriter.ConfigLookupResult.NotFound -> false.also {
+                logger.info { "No updatable configuration item found with property path '$property'" }
+            }
 
-            clientCredentialOrigins.size > 1 ->
-                error(
-                    "Multiple origins found for client secret `$CLIENT_SECRET_PROPERTY_PATH`: '$clientCredentialOrigins'"
-                )
+            ConfigurationWriter.ConfigLookupResult.NotWritable -> false.also {
+                logger.info { "Configuration item with property path '$property' is not sourced from a writable resource.'" }
+            }
+        }
 
-            else -> return clientCredentialOrigins.first()
+    private fun writeNewSecret(secret: String): RenewClientSecretResult {
+        val newIdpCredentials = config.idpCredentials.copy(
+            clientSecret = ClientSecret(secret),
+            lastCredentialRenewalTime = LastUpdatedAt(Instant.now()),
+        )
+        val newCdrConfig = config.copy(
+            idpCredentials = newIdpCredentials
+        )
+
+        return configurationWriter.updateClientServiceConfiguration(newCdrConfig).let { updateResult ->
+            when (updateResult) {
+                is ConfigurationWriter.Result.Failure -> RenewClientSecretResult.Failure.also {
+                    logger.error { "Failed to update client service configuration with new client secret: ${updateResult.errors}" }
+                }
+
+                is ConfigurationWriter.Result.Success -> RenewClientSecretResult.Success
+            }
         }
     }
-
-    private val Origin.fileBackedResource: Resource
-        get() =
-            when (this) {
-                is TextResourceOrigin -> this.resource
-                else -> error("Don't know how to get file resource for origin type: '${this::class.qualifiedName}'")
-            }
-
-    private val Resource.writeableResource: WritableResource
-        get() = FileSystemResource(this.file).apply {
-            require(isWritable) { "Resource is not writable: '$this'" }
-        }
-
-    private val Resource.fileTypeFromExtension: FileType
-        get() =
-            when (this.file.extension) {
-                "yml", "yaml" -> FileType.YAML
-                "properties" -> FileType.PROPERTIES
-                else -> error("Don't know file type for extension: '${this.file.extension}'; resource: '$this'")
-            }
-
-    private fun updateYamlSource(yamlResource: WritableResource, newSecret: String): Unit =
-        YAMLMapper().run {
-            val yamlNode: JsonNode = readTree(yamlResource.inputStream)
-            (yamlNode.get(CLIENT_PROPERTY).get(IDP_CREDENTIALS_PROPERTY) as ObjectNode).apply {
-                put(CLIENT_SECRET_PROPERTY, newSecret)
-            }
-            writeValue(yamlResource.outputStream.writer(), yamlNode)
-        }
-
-    private fun updatePropertySource(propertiesResource: WritableResource, newSecret: String): Unit =
-        Properties().run {
-            load(propertiesResource.inputStream)
-            setProperty(CLIENT_SECRET_PROPERTY_PATH, newSecret)
-            store(propertiesResource.outputStream.writer(), null)
-        }
 
     private fun getNewSecret(): String =
         cdrApiClient.renewClientCredential(
@@ -123,20 +87,14 @@ class ClientSecretRenewalService(
             }
         }
 
-    private enum class FileType {
-        YAML,
-        PROPERTIES
-    }
-
     companion object {
         const val CLIENT_PROPERTY = "client"
         const val IDP_CREDENTIALS_PROPERTY = "idp-credentials"
         const val CLIENT_SECRET_PROPERTY = "client-secret"
+        const val CLIENT_SECRET_LAST_UPDATE_PROPERTY = "last-credential-renewal-time"
         const val CLIENT_SECRET_PROPERTY_PATH = "$CLIENT_PROPERTY.$IDP_CREDENTIALS_PROPERTY.$CLIENT_SECRET_PROPERTY"
+        const val CLIENT_SECRET_LAST_UPDATE_PROPERTY_PATH = "$CLIENT_PROPERTY.$IDP_CREDENTIALS_PROPERTY.$CLIENT_SECRET_LAST_UPDATE_PROPERTY"
     }
 
-    sealed class RenewClientSecretResult {
-        data class Success(val secretSource: Resource) : RenewClientSecretResult()
-        data class RenewError(val cause: Throwable) : RenewClientSecretResult()
-    }
+
 }

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigurationWriter.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigurationWriter.kt
@@ -1,0 +1,335 @@
+package com.swisscom.health.des.cdr.client.handler
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.swisscom.health.des.cdr.client.config.CdrClientConfig
+import com.swisscom.health.des.cdr.client.config.PropertyNameAware
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.origin.Origin
+import org.springframework.boot.origin.OriginLookup
+import org.springframework.boot.origin.PropertySourceOrigin
+import org.springframework.boot.origin.TextResourceOrigin
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.io.FileSystemResource
+import org.springframework.core.io.Resource
+import org.springframework.core.io.WritableResource
+import org.springframework.stereotype.Service
+import kotlin.reflect.full.memberProperties
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+internal class ConfigurationWriter(
+    private val currentConfig: CdrClientConfig,
+    private val context: ConfigurableApplicationContext,
+) {
+
+    sealed interface ConfigLookupResult {
+        object NotFound : ConfigLookupResult
+        object NotWritable : ConfigLookupResult
+        object Writable : ConfigLookupResult
+    }
+
+    fun isWritableConfigurationItem(propertyPath: String): ConfigLookupResult =
+        collectUpdatableConfigurationItems(currentConfig, currentConfig)
+            .firstOrNull { it.propertyPath == propertyPath && it is UpdatableConfigurationItem.WritableResourceConfigurationItem }
+            .let { updatableConfigItem: UpdatableConfigurationItem? ->
+                return when (updatableConfigItem) {
+                    null -> ConfigLookupResult.NotFound
+                    is UpdatableConfigurationItem.UnknownSourceConfigurationItem -> ConfigLookupResult.NotWritable
+                    is UpdatableConfigurationItem.WritableResourceConfigurationItem -> ConfigLookupResult.Writable
+                }
+            }
+
+    sealed interface Result {
+        object Success : Result
+        data class Failure(val errors: Map<String, Any>) : Result
+    }
+
+    fun updateClientServiceConfiguration(newConfig: CdrClientConfig): Result = runCatching {
+        logger.trace { "New CDR client config: '$newConfig'" }
+
+        validate(newConfig).let { validationErrors: Map<String, Any> ->
+            if (validationErrors.isNotEmpty()) {
+                Result.Failure(validationErrors)
+            } else {
+                val updatableItems: List<UpdatableConfigurationItem> = collectUpdatableConfigurationItems(currentConfig, newConfig)
+                logger.trace { "Updatable configuration items found: '$updatableItems'" }
+
+                updatableItems
+                    .filter { updatableConfigItem ->
+                        updatableConfigItem.newValue != updatableConfigItem.currentValue
+                    }.filter { changedConfigItem ->
+                        (changedConfigItem is UpdatableConfigurationItem.WritableResourceConfigurationItem)
+                            .also { isWritable ->
+                                if (!isWritable) {
+                                    // Not really cool as we will create partial updates. But as we do not have a rollback strategy (yet),
+                                    // the update might be partial anyway, if we do not fail on the first changed property.
+                                    // TODO: Implement a rollback strategy!
+                                    logger.warn {
+                                        "Configuration item '${changedConfigItem.propertyPath}' was changed, but is not writable! " +
+                                                "Skipping update for this item!"
+                                    }
+                                }
+                            }
+                    }.map { changedWritableConfigItem ->
+                        changedWritableConfigItem as UpdatableConfigurationItem.WritableResourceConfigurationItem
+                    }.forEach { changedWritableConfigItem: UpdatableConfigurationItem.WritableResourceConfigurationItem ->
+                        logger.info { "Updating configuration item: '${changedWritableConfigItem.propertyPath}'" }
+                        logger.trace { "Configuration item details: '$changedWritableConfigItem'" }
+                        when (changedWritableConfigItem.writableResource.fileTypeFromExtension) {
+                            FileType.YAML -> updateYamlSource(changedWritableConfigItem)
+                            FileType.PROPERTIES -> TODO() //updatePropertySource(changedConfigItem)
+                            // TODO: change to error once we have a rollback strategy
+                            null -> logger.warn { "Property source has unknown file extension: ${changedWritableConfigItem.writableResource.filename}" }
+                        }
+                    }
+
+                Result.Success
+            }
+        }
+    }.getOrElse { exception ->
+        Result.Failure(mapOf("error" to exception)).also {
+            logger.error(exception) { "Failed to update configuration items" }
+        }
+    }
+
+    private fun updateYamlSource(changedConfigItem: UpdatableConfigurationItem.WritableResourceConfigurationItem): Unit =
+        YAMLMapper().run {
+            val yamlNode: JsonNode = readTree(changedConfigItem.writableResource.inputStream)
+            var tmpNode = yamlNode as ObjectNode
+            val remainingNodeNames = ArrayDeque(changedConfigItem.propertyPath.split("."))
+            val toBeUpdatedNodeName = remainingNodeNames.removeLast()
+            while (remainingNodeNames.isNotEmpty()) {
+                tmpNode = tmpNode.get(remainingNodeNames.removeFirst()) as ObjectNode
+            }
+            tmpNode.apply {
+                when (changedConfigItem.newValue) {
+                    is Collection<*> -> TODO() // need to handle the collection of connectors!
+                    else -> {
+                        // we have to go to string first as the value might be one a value class, Duration, DataSize, etc., anything that
+                        // SpringBoot's unmarshalling magic creates from what was originally a string
+                        val stringValue = changedConfigItem.newValue.toString()
+                        val storedValue = runCatching { stringValue.toBooleanStrict().also { put(toBeUpdatedNodeName, it) } }
+                            .recoverCatching { stringValue.toInt().also { put(toBeUpdatedNodeName, it) } }
+                            .recoverCatching { stringValue.toFloat().also { put(toBeUpdatedNodeName, it) } }
+                            .getOrElse { stringValue.also { put(toBeUpdatedNodeName, it) } }
+                        logger.debug { "set '${changedConfigItem.propertyPath}' to '$storedValue' as type '${storedValue::class}'" }
+                    }
+                }
+            }
+
+            writeValue(changedConfigItem.writableResource.outputStream.writer(), yamlNode)
+        }
+
+//    private fun updatePropertySource(changedConfigItem: UpdatableConfigurationItem): Unit =
+//        Properties().run {
+//            load(propertiesResource.inputStream)
+//            setProperty(CLIENT_SECRET_PROPERTY_PATH, newSecret)
+//            store(propertiesResource.outputStream.writer(), null)
+//        }
+
+    private fun collectUpdatableConfigurationItems(
+        currentConfigItemValue: PropertyNameAware, newConfigItemValue: PropertyNameAware,
+    ): List<UpdatableConfigurationItem> {
+
+        data class ConfigItemContainer(
+            val current: PropertyNameAware,
+            val new: PropertyNameAware,
+            val propertyPath: List<String>,
+        )
+
+        tailrec fun walkConfigurationItemTree(
+            configItems: ArrayDeque<ConfigItemContainer>,
+            updatableConfigItemCollector: MutableList<UpdatableConfigurationItem>,
+        ) {
+            if (configItems.isEmpty()) {
+                // the stack is empty; we have walked the entire tree of updatable configuration items and are done
+                return
+            }
+
+            // pop the most recently added configuration node from the stack
+            val (currentConfigItem, newConfigItem, propertyPath) = configItems.removeLast()
+
+            // some sanity checks to try and make sure the object tree of the new and old configuration is the same
+            require(currentConfigItem::class == newConfigItem::class) {
+                "Current and new configuration items must be of the same type: '${currentConfigItem::class}' vs '${newConfigItem::class}'"
+            }
+            require(currentConfigItem.propertyName == newConfigItem.propertyName) {
+                "Current and new configuration items must have the same property name: '${currentConfigItem.propertyName}' vs '${newConfigItem.propertyName}'"
+            }
+
+            // get the updatable configuration item children from both configuration object tree nodes, to gather both the before and after values
+            val propertyNameAwareChildren: List<Pair<PropertyNameAware, PropertyNameAware>> =
+                getPropertyNameAwareChildren(currentConfigItem).zip(getPropertyNameAwareChildren(newConfigItem))
+
+            if (propertyNameAwareChildren.isEmpty()) {
+                // if we have reached a leaf node in the tree of updatable configuration items (no more updatable child nodes),
+                // we try to resolve its property source and store the node for potential updates
+                getPropertySource(propertyPath.joinToString(separator = "."))?.let { propertySource ->
+                    logger.debug { "Writable resource found for configuration item '${propertyPath.joinToString(separator = ".")}': '$propertySource'" }
+                    updatableConfigItemCollector.add(
+                        UpdatableConfigurationItem.WritableResourceConfigurationItem(
+                            propertyPath = propertyPath.joinToString(separator = "."),
+                            writableResource = propertySource,
+                            currentValue = currentConfigItem,
+                            newValue = newConfigItem,
+                        )
+                    )
+
+                } ?: run {
+                    logger.debug { "No writable resource found for configuration item '${propertyPath.joinToString(separator = ".")}'" }
+                    updatableConfigItemCollector.add(
+                        UpdatableConfigurationItem.UnknownSourceConfigurationItem(
+                            propertyPath = propertyPath.joinToString(separator = "."),
+                            currentValue = currentConfigItem,
+                            newValue = newConfigItem,
+                        )
+                    )
+                }
+            } else {
+                // if more updatable child nodes are present, then push all updatable child nodes onto the stack
+                propertyNameAwareChildren.forEach { (currentChild, newChild) ->
+                    val propertyNameAwarePair = ConfigItemContainer(
+                        current = currentChild,
+                        new = newChild,
+                        propertyPath = propertyPath + currentChild.propertyName
+                    )
+                    configItems.add(propertyNameAwarePair)
+                }
+            }
+
+            // continue descending into the tree of updatable configuration items until we hit a leaf node
+            walkConfigurationItemTree(
+                configItems = configItems,
+                updatableConfigItemCollector = updatableConfigItemCollector,
+            )
+        }
+
+        val updatableConfigItems = mutableListOf<UpdatableConfigurationItem>()
+        // start walking the tree of updatable configuration items, starting with the root node
+        walkConfigurationItemTree(
+            configItems = ArrayDeque(
+                listOf(
+                    ConfigItemContainer(
+                        current = currentConfigItemValue,
+                        new = newConfigItemValue,
+                        propertyPath = listOf(currentConfigItemValue.propertyName),
+                    )
+                )
+            ),
+            updatableConfigItemCollector = updatableConfigItems,
+        )
+
+        return updatableConfigItems as List<UpdatableConfigurationItem>
+    }
+
+    private fun getPropertySource(propertyPath: String): WritableResource? {
+        val origin: WritableResource? = runCatching {
+            findPropertyOrigin(propertyPath)
+        }.mapCatching { origin ->
+            origin?.fileBackedResource
+        }.mapCatching { resource: Resource? ->
+            resource?.writeableResource
+        }.getOrThrow()
+
+        return origin
+    }
+
+    /**
+     * Currently it is not possible to determine the "effective origin" of a property value based on the precedence rules
+     * for property sources in SpringBoot. But it might be in the future:
+     * [SpringBoot Feature Request](https://github.com/spring-projects/spring-boot/issues/21613)
+     *
+     * As we cannot determine the effective origin and then check whether it is an updatable text resource, we search all
+     * available property sources for the client secret property and fail if we find no origin. The local development setup
+     * may report more than one origin as it uses multiple profiles. If more then once origin is found we log a warning
+     * and return the first one from the list of origins.
+     */
+    private fun findPropertyOrigin(propertyPath: String): Origin? {
+        @Suppress("UNCHECKED_CAST")
+        val origins = context.environment.propertySources
+            // at the time of writing, there exist only OriginLookup<String> implementations on the classpath
+            .mapNotNull { if (it is OriginLookup<*>) it as OriginLookup<String> else null }
+            .mapNotNull { it.getOrigin(propertyPath) }
+            // if configuration files are added via the `spring.config.additional-local` property, then a property from an additional
+            // location ends up in two origins, a property source origin that encapsulates the actual origin, and that origin directly.
+            .map { if (it is PropertySourceOrigin) it.origin else it }
+            .toSet()
+
+        when {
+            origins.isEmpty() ->
+                logger.debug { "No origin found for property `$propertyPath`" }
+
+            origins.size > 1 -> {
+                logger.warn { "Multiple origins found for property `$propertyPath`: '$origins'; picking first one, your mileage might vary!" }
+            }
+        }
+
+        return origins.firstOrNull()
+    }
+
+    private fun getPropertyNameAwareChildren(value: PropertyNameAware): List<PropertyNameAware> =
+        value::class.memberProperties
+            .mapNotNull { kProperty -> kProperty.call(value) }
+            .filter { propertyValue -> propertyValue is PropertyNameAware }
+            .map { propertyValue -> propertyValue as PropertyNameAware }
+            .toList()
+
+    /**
+     * TODO: Implement!
+     */
+    private fun validate(config: CdrClientConfig): Map<String, Any> {
+        logger.debug { "config to validate: '$config'" }
+//        return mapOf("fakeError1" to "fake Error 1 Value", "fakeError2" to "fake Error 2 Value")
+        return emptyMap()
+    }
+
+    private val Origin.fileBackedResource: Resource?
+        get() =
+            when (this) {
+                is TextResourceOrigin -> this.resource
+                else -> null.also { logger.warn { "Don't know how to get file resource for origin type: '${this::class.qualifiedName}'" } }
+            }
+
+    private val Resource.writeableResource: WritableResource?
+        get() = FileSystemResource(this.file).run {
+            when (isWritable) {
+                true -> this.also { logger.debug { "Resource is writable: '$this'" } }
+                false -> null.also { logger.warn { "Resource is not writable: '$this'" } }
+            }
+        }
+
+    private val Resource.fileTypeFromExtension: FileType?
+        get() =
+            when (this.file.extension) {
+                "yml", "yaml" -> FileType.YAML
+                "properties" -> FileType.PROPERTIES
+                else -> null.also { logger.warn { "Don't know file type for extension: '${this.file.extension}'; resource: '$this'" } }
+            }
+
+    private enum class FileType {
+        YAML,
+        PROPERTIES
+    }
+
+    internal sealed interface UpdatableConfigurationItem {
+        val propertyPath: String
+        val currentValue: Any
+        val newValue: Any
+
+        data class WritableResourceConfigurationItem(
+            override val propertyPath: String,
+            override val currentValue: Any,
+            override val newValue: Any,
+            val writableResource: WritableResource,
+        ) : UpdatableConfigurationItem
+
+        data class UnknownSourceConfigurationItem(
+            override val propertyPath: String,
+            override val currentValue: Any,
+            override val newValue: Any,
+        ) : UpdatableConfigurationItem
+    }
+}

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/PullFileHandling.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/PullFileHandling.kt
@@ -24,7 +24,7 @@ internal const val PULL_RESULT_ID_HEADER = "cdr-document-uuid"
  */
 @Component
 @Suppress("TooManyFunctions")
-class PullFileHandling(
+internal class PullFileHandling(
     private val tracer: Tracer,
     private val cdrApiClient: CdrApiClient,
     private val xmlParser: XmlUtil

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/RetryUploadFileHandling.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/RetryUploadFileHandling.kt
@@ -31,7 +31,7 @@ private val logger = KotlinLogging.logger {}
  */
 @Component
 @Suppress("TooManyFunctions", "LongParameterList")
-class RetryUploadFileHandling(
+internal class RetryUploadFileHandling(
     private val cdrClientConfig: CdrClientConfig,
     private val tracer: Tracer,
     private val cdrApiClient: CdrApiClient,
@@ -44,7 +44,7 @@ class RetryUploadFileHandling(
     suspend fun uploadRetrying(file: Path, connector: CdrClientConfig.Connector) {
         logger.debug { "Uploading file '$file'" }
         var retryCount = 0
-        var retryNeeded = false
+        var retryNeeded: Boolean
 
         // a successful rename of the file to upload should guarantee that we can also delete it after a successful upload,
         // and thus prevent duplicate uploads of a file if we fail to delete or archive it after a successful upload

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ShutdownService.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ShutdownService.kt
@@ -1,0 +1,62 @@
+package com.swisscom.health.des.cdr.client.handler
+
+import com.swisscom.health.des.cdr.client.common.Constants.CONFIG_CHANGE_EXIT_CODE
+import com.swisscom.health.des.cdr.client.common.Constants.SHUTDOWN_DELAY
+import com.swisscom.health.des.cdr.client.common.Constants.UNKNOWN_EXIT_CODE
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.time.delay
+import org.springframework.boot.SpringApplication
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.stereotype.Service
+import kotlin.system.exitProcess
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+internal class ShutdownService(
+    private val context: ConfigurableApplicationContext,
+) {
+
+    @OptIn(DelicateCoroutinesApi::class)
+    internal fun scheduleShutdown(shutdownTrigger: ShutdownTrigger) {
+        if (SHUTDOWN_GUARD.tryLock()) {
+            GlobalScope.launch {
+                logger.info { "Shutdown requested for reason: '$shutdownTrigger'" }
+                // Wait a bit to allow the http response to be sent before shutting down
+                delay(SHUTDOWN_DELAY)
+                // previously producing the exit code was a single line:
+                // `exitProcess(SpringApplication.exit(context, { shutdownTrigger.exitCode }))`
+                // however, there must be some sort of race condition present; half the time the exit code was 0 instead of the code specified in the
+                // `shutdownTrigger`
+                SpringApplication.exit(context).let { contextExitCode ->
+                    if (contextExitCode != 0) {
+                        logger.warn { "Spring application context did not exit cleanly, exit code: '$contextExitCode'" }
+                    }
+                }
+                exitProcess(shutdownTrigger.exitCode)
+            }
+        } else {
+            logger.info { "Shutdown already scheduled, ignoring request with given reason: '$shutdownTrigger'" }
+        }
+    }
+
+    enum class ShutdownTrigger(val reason: String, val exitCode: Int) {
+        CONFIG_CHANGE("configurationChange", CONFIG_CHANGE_EXIT_CODE),
+        UNKNOWN("unknown", UNKNOWN_EXIT_CODE);
+
+        companion object {
+            fun fromReason(reason: String): ShutdownTrigger {
+                return entries.firstOrNull { it.reason == reason } ?: UNKNOWN
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        private val SHUTDOWN_GUARD = Mutex()
+    }
+}

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/http/HealthIndicators.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/http/HealthIndicators.kt
@@ -15,7 +15,7 @@ internal class HealthIndicators(
     @Bean
     fun fileSynchronizationHealthIndicator(): HealthIndicator =
         HealthIndicator {
-            when (config.fileSynchronizationEnabled) {
+            when (config.fileSynchronizationEnabled.value) {
                 true -> Health.Builder(Status(FILE_SYNCHRONIZATION_STATUS_ENABLED)).withDetail("fileSynchronizationEnabled", true)
                 false -> Health.Builder(Status(FILE_SYNCHRONIZATION_STATUS_DISABLED)).withDetail("fileSynchronizationEnabled", false)
             }.build()

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/installer/Installer.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/installer/Installer.kt
@@ -15,7 +15,7 @@ private val logger = KotlinLogging.logger {}
 
 fun Path.toSpringConfigString(): String = this.toString().replace("\\", "/")
 
-class Installer(private val scanner: Scanner = Scanner(System.`in`)) {
+internal class Installer(private val scanner: Scanner = Scanner(System.`in`)) {
 
     fun install() {
         println("###############################################")
@@ -96,7 +96,7 @@ class Installer(private val scanner: Scanner = Scanner(System.`in`)) {
             .plus("client.idp-credentials.$CONF_CLIENT_SECRET=$clientSecret\n")
             .let {
                 if (updateCredentials.lowercase() in listOf("n", "no", "non", "nein", "false")) {
-                    it.plus("client.idp-credentials.renew-credential-at-startup=false\n")
+                    it.plus("client.idp-credentials.renew-credential=false\n")
                 } else {
                     it
                 }

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/scheduling/ClientSecretRenewalScheduler.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/scheduling/ClientSecretRenewalScheduler.kt
@@ -1,48 +1,44 @@
 package com.swisscom.health.des.cdr.client.scheduling
 
-import com.swisscom.health.des.cdr.client.config.CdrClientConfig
 import com.swisscom.health.des.cdr.client.handler.ClientSecretRenewalService
+import com.swisscom.health.des.cdr.client.handler.ShutdownService
 import com.swisscom.health.des.cdr.client.handler.withSpan
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.tracing.Tracer
 import jakarta.annotation.PostConstruct
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.cloud.context.refresh.ContextRefresher
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
 
 @Service
-@ConditionalOnProperty(prefix = "client.idp-credentials", name = ["renew-credential-at-startup"], havingValue = "true")
-class ClientSecretRenewalScheduler(
+@ConditionalOnProperty(prefix = "client.idp-credentials", name = ["renew-credential"], havingValue = "true")
+internal class ClientSecretRenewalScheduler(
     private val clientSecretRenewalService: ClientSecretRenewalService,
-    @Qualifier("configDataContextRefresher")
-    private val contextRefresher: ContextRefresher,
-    private val config: CdrClientConfig,
+    private val shutdownService: ShutdownService,
     private val tracer: Tracer,
 ) {
 
     @PostConstruct
-    fun reportIn() = logger.info { "Automatic client secret renewal is '${if (config.idpCredentials.renewCredentialAtStartup) "on" else "off"}'" }
+    fun reportIn() = logger.info { "Automatic client secret renewal is active!" }
 
-    @Scheduled(fixedDelayString = "365d", initialDelayString = "1s")
+    @Scheduled(
+        fixedDelayString = "#{ @'client-com.swisscom.health.des.cdr.client.config.CdrClientConfig'.getIdpCredentials().getMaxCredentialAge().toMillis() }",
+        initialDelayString= "#{ @'client-com.swisscom.health.des.cdr.client.config.CdrClientConfig'.getIdpCredentials().getMillisUntilNextCredentialRenewal() }"
+    )
     fun renewClientSecret(): Unit = tracer.withSpan("Renew Client Secret") {
         logger.info { "Renewing client secret..." }
         val result = clientSecretRenewalService.renewClientSecret()
         when (result) {
             is ClientSecretRenewalService.RenewClientSecretResult.Success -> {
-                logger.debug { "Resource containing secret: '${result.secretSource}'" }
                 logger.debug { "Refreshing Spring context due to configuration update" }
-                contextRefresher.refresh().also { refreshedKeys ->
-                    logger.debug { "Refreshed keys: $refreshedKeys" }
-                }
                 logger.info { "Renewing client secret done." }
+                shutdownService.scheduleShutdown(ShutdownService.ShutdownTrigger.CONFIG_CHANGE)
             }
 
-            is ClientSecretRenewalService.RenewClientSecretResult.RenewError -> {
-                logger.error { "Failed to renew client secret: '${result.cause.message}'" }
+            is ClientSecretRenewalService.RenewClientSecretResult.Failure -> {
+                logger.error { "Failed to renew client secret" }
             }
         }
     }

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/scheduling/DocumentDownloadScheduler.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/scheduling/DocumentDownloadScheduler.kt
@@ -21,7 +21,7 @@ private val logger = KotlinLogging.logger {}
  */
 @Service
 @Profile("!noDownloadScheduler")
-class DocumentDownloadScheduler(
+internal class DocumentDownloadScheduler(
     private val cdrClientConfig: CdrClientConfig,
     private val pullFileHandling: PullFileHandling,
     @Qualifier("limitedParallelismCdrDownloadsDispatcher")

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/scheduling/DocumentUploadSchedulers.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/scheduling/DocumentUploadSchedulers.kt
@@ -58,7 +58,7 @@ private val logger = KotlinLogging.logger {}
 @Service
 @Profile("!noEventTriggerUploadScheduler")
 @Suppress("LongParameterList")
-class EventTriggerUploadScheduler(
+internal class EventTriggerUploadScheduler(
     private val config: CdrClientConfig,
     private val tracer: Tracer,
     @Qualifier("limitedParallelismCdrUploadsDispatcher")
@@ -188,7 +188,7 @@ class EventTriggerUploadScheduler(
 @Service
 @Profile("!noPollingUploadScheduler")
 @Suppress("LongParameterList")
-class PollingUploadScheduler(
+internal class PollingUploadScheduler(
     private val config: CdrClientConfig,
     private val tracer: Tracer,
     @Qualifier("limitedParallelismCdrUploadsDispatcher")
@@ -305,7 +305,7 @@ class PollingUploadScheduler(
 
 }
 
-abstract class BaseUploadScheduler(
+internal abstract class BaseUploadScheduler(
     private val config: CdrClientConfig,
     private val retryUploadFileHandling: RetryUploadFileHandling,
     @Qualifier("limitedParallelismCdrUploadsDispatcher")

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/xml/DocumentType.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/xml/DocumentType.kt
@@ -30,7 +30,7 @@ enum class DocumentType(val uri: String, val prefix: String) {
 
         @JsonCreator
         @JvmStatic
-        fun fromValue(value: String): DocumentType {
+        fun fromName(value: String): DocumentType {
             return entries.firstOrNull { it.name.equals(value, ignoreCase = true)} ?: UNDEFINED
         }
     }

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/xml/XmlUtil.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/xml/XmlUtil.kt
@@ -7,7 +7,7 @@ import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
 
 @Service
-class XmlUtil {
+internal class XmlUtil {
 
     fun findSchemaDefinition(doc: Document): DocumentType {
         fun isEven(value: Int) = value % 2 == 0

--- a/cdr-client-service/src/main/resources/config/application-client.yaml
+++ b/cdr-client-service/src/main/resources/config/application-client.yaml
@@ -1,4 +1,6 @@
+---
 client:
+  file-synchronization-enabled: true
   local-folder: ${cdrClient.localFolder:${java.io.tmpdir}/cdr_download}
   idp-credentials:
     tenant-id: ${CDR_B2C_TENANT_ID:test-tenant-client-id} # `test-tenant-client-id` is the required value if the MockOauth2Server is used; see its `config.json`
@@ -8,7 +10,9 @@ client:
     # locations, which currently also fails the update
     scopes:
       - https://${CDR_CLIENT_SCOPE_PREFIX:}identity.health.swisscom.ch/CdrApi/.default
-    renew-credential-at-startup: ${CDR_CLIENT_RENEW_CREDENTIAL_AT_STARTUP:true}
+    renew-credential: ${CDR_CLIENT_RENEW_CREDENTIAL_AT_STARTUP:true}
+    max-credential-age: 365d
+    last-credential-renewal-time: 1970-01-01T00:00:00Z
   idp-endpoint: https://login.microsoftonline.com/${client.idp-credentials.tenant-id}/
   schedule-delay: PT10M
   files-in-progress-cache-size: 10MB

--- a/cdr-client-service/src/main/resources/config/application-dev.yaml
+++ b/cdr-client-service/src/main/resources/config/application-dev.yaml
@@ -4,8 +4,9 @@ client:
   idp-credentials:
     scopes:
       - https://dev.identity.health.swisscom.ch/CdrApi/.default
-    renew-credential-at-startup: false
     client-secret: ${CDR_CLIENT_SECRET:Placeholder_test-secret}
+    renew-credential: true
+    last-credential-renewal-time: 1970-01-01T00:00:00Z
   cdr-api:
     scheme: http
     port: 9090

--- a/cdr-client-service/src/main/resources/config/application.yaml
+++ b/cdr-client-service/src/main/resources/config/application.yaml
@@ -1,3 +1,4 @@
+
 spring:
   main:
     web-application-type: REACTIVE
@@ -15,10 +16,10 @@ spring:
         size: 5
       shutdown:
         # Spring's default shutdown behavior is to wait for scheduled tasks to finish and once all tasks have finished, to shut down the task executor.
-        # In the absence of exceptions our scheduled tasks never finish as they are the source of a "hot" kotlin flow. In order to avoid the delay in
-        # the application shutdown while Spring waits for the task executor to shut down (and a stacktrace in the logs at the end of the wait time),
-        # we need to tell Spring to cancel the tasks themselves, and to do so immediately.
-        # In our case this means cancellation of the CoroutineScope we are running the tasks in; this should translate into a graceful shutdown of the client.
+        # In the absence of exceptions, our scheduled tasks never finish as they are the source of a "hot" kotlin flow. To avoid the delay in the
+        # application shutdown while Spring waits for the task executor to shut down (and a stacktrace in the logs at the end of the wait time), we
+        # need to tell Spring to cancel the tasks themselves, and to do so immediately.
+        # In our case, this means cancellation of the CoroutineScope we are running the tasks in; this should translate into a graceful shutdown of the client.
         await-termination-period: 0s
         await-termination: true
   jmx:

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/AlwaysSameTempDirFactory.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/AlwaysSameTempDirFactory.kt
@@ -7,7 +7,7 @@ import java.nio.file.Path
 import kotlin.io.path.createDirectory
 import kotlin.io.path.exists
 
-class AlwaysSameTempDirFactory: TempDirFactory {
+internal class AlwaysSameTempDirFactory: TempDirFactory {
     override fun createTempDirectory(elementContext: AnnotatedElementContext?, extensionContext: ExtensionContext?): Path =
         Path.of(System.getProperty("java.io.tmpdir"), "cdr-client-test-source").also { path -> if (!path.exists()) path.createDirectory() }
 }

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/PullDocumentDownloadSchedulerAndFileHandlerMultipleConnectorTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/PullDocumentDownloadSchedulerAndFileHandlerMultipleConnectorTest.kt
@@ -107,28 +107,28 @@ internal class PullDocumentDownloadSchedulerAndFileHandlerMultipleConnectorTest 
         cdrServiceMock = MockWebServer()
         cdrServiceMock.start()
 
-        val endpoint = CdrClientConfig.Endpoint().apply {
-            host = cdrServiceMock.hostName
-            basePath = "documents"
-            scheme = "http"
-            port = cdrServiceMock.port
-        }
+        val endpoint = CdrClientConfig.Endpoint(
+            host = cdrServiceMock.hostName,
+            basePath = "documents",
+            scheme = "http",
+            port = cdrServiceMock.port,
+        )
         val connector1 =
-            CdrClientConfig.Connector().apply {
-                connectorId = connectorId1
-                targetFolder = tmpDir.resolve(directory1)
-                sourceFolder = tmpDir.resolve(directory1).resolve("source")
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-            }
+            CdrClientConfig.Connector(
+                connectorId = connectorId1,
+                targetFolder = tmpDir.resolve(directory1),
+                sourceFolder = tmpDir.resolve(directory1).resolve("source"),
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+            )
         val connector2 =
-            CdrClientConfig.Connector().apply {
-                connectorId = connectorId2
-                targetFolder = tmpDir.resolve(directory2)
-                sourceFolder = tmpDir.resolve(directory2).resolve("source")
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.PRODUCTION
-            }
+            CdrClientConfig.Connector(
+                connectorId = connectorId2,
+                targetFolder = tmpDir.resolve(directory2),
+                sourceFolder = tmpDir.resolve(directory2).resolve("source"),
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.PRODUCTION,
+            )
         val localFolder = tmpDir.resolve(inflightFolder)
 
         connector1.sourceFolder.createDirectories()

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/StartupHelperTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/StartupHelperTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.nio.file.Paths
 import kotlin.io.path.absolutePathString
 
-class StartupHelperTest {
+internal class StartupHelperTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["dev", "test", "customer,dev"])

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/config/CdrClientConfigTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/config/CdrClientConfigTest.kt
@@ -1,6 +1,5 @@
 package com.swisscom.health.des.cdr.client.config
 
-import com.swisscom.health.des.cdr.client.config.CdrClientConfig.IdpCredentials
 import com.swisscom.health.des.cdr.client.xml.DocumentType
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -19,7 +18,7 @@ import java.nio.file.Path
 import java.time.Duration
 import java.util.stream.Stream
 
-class CdrClientConfigTest {
+internal class CdrClientConfigTest {
 
     @TempDir
     private lateinit var localFolder0: Path
@@ -99,43 +98,45 @@ class CdrClientConfigTest {
     }
 
     private fun createCdrClientConfig(customers: List<CdrClientConfig.Connector>, defaultLocalFolder: Path = localFolder0): CdrClientConfig {
-        return CdrClientConfig().apply {
-            scheduleDelay = Duration.ofSeconds(1)
-            localFolder = defaultLocalFolder
-            cdrApi = CdrClientConfig.Endpoint().apply {
-                scheme = "http"
-                host = "localhost"
-                port = 8080
-                basePath = "api"
-            }
-            credentialApi = CdrClientConfig.Endpoint().apply {
-                scheme = "http"
-                host = "localhost"
-                port = 8080
-                basePath = "client-credentials"
-            }
-            customer = customers
-            pullThreadPoolSize = 1
-            pushThreadPoolSize = 1
-            retryDelay = listOf(Duration.ofSeconds(1))
-            filesInProgressCacheSize = DataSize.ofMegabytes(1)
-            idpCredentials = IdpCredentials().apply {
-                tenantId = "tenantId"
-                clientId = "clientId"
-                clientSecret = "secret"
-                scopes = listOf("CDR")
-            }
-            idpEndpoint = URL("http://localhost")
-            fileBusyTestStrategy = CdrClientConfig.FileBusyTestStrategy.FILE_SIZE_CHANGED
-            fileBusyTestInterval = Duration.ofMillis(250)
-            fileBusyTestTimeout = Duration.ofSeconds(1)
-            retryTemplate = CdrClientConfig.RetryTemplateConfig().apply {
-                retries = 3
-                initialDelay = Duration.ofSeconds(5)
-                maxDelay = Duration.ofSeconds(5)
-                multiplier = 2.0
-            }
-        }
+        return CdrClientConfig(
+            fileSynchronizationEnabled = FileSynchronization.ENABLED,
+            scheduleDelay = Duration.ofSeconds(1),
+            localFolder = defaultLocalFolder,
+            cdrApi = CdrClientConfig.Endpoint(
+                scheme = "http",
+                host = "localhost",
+                port = 8080,
+                basePath = "api",
+            ),
+            credentialApi = CdrClientConfig.Endpoint(
+                scheme = "http",
+                host = "localhost",
+                port = 8080,
+                basePath = "client-credentials",
+            ),
+            customer = customers,
+            pullThreadPoolSize = 1,
+            pushThreadPoolSize = 1,
+            retryDelay = listOf(Duration.ofSeconds(1)),
+            filesInProgressCacheSize = DataSize.ofMegabytes(1),
+            idpCredentials = IdpCredentials(
+                tenantId = "tenantId",
+                clientId = "clientId",
+                clientSecret = ClientSecret("secret"),
+                scopes = listOf("CDR"),
+                renewCredential = RenewCredential(true)
+            ),
+            idpEndpoint = URL("http://localhost"),
+            fileBusyTestStrategy = CdrClientConfig.FileBusyTestStrategy.FILE_SIZE_CHANGED,
+            fileBusyTestInterval = Duration.ofMillis(250),
+            fileBusyTestTimeout = Duration.ofSeconds(1),
+            retryTemplate = CdrClientConfig.RetryTemplateConfig(
+                retries = 3,
+                initialDelay = Duration.ofSeconds(5),
+                maxDelay = Duration.ofSeconds(5),
+                multiplier = 2.0,
+            ),
+        )
     }
 
     companion object {
@@ -184,23 +185,23 @@ class CdrClientConfigTest {
                 FORUM_DATENAUSTAUSCH_MEDIA_TYPE,
                 CdrClientConfig.Mode.TEST,
                 mapOf(
-                    DocumentType.CONTAINER to CdrClientConfig.Connector.DocTypeFolders().apply { targetFolder = targetFolder0 },
-                    DocumentType.CREDIT to CdrClientConfig.Connector.DocTypeFolders().apply { targetFolder = targetFolder0 },
-                    DocumentType.FORM to CdrClientConfig.Connector.DocTypeFolders().apply { targetFolder = targetFolder0 },
-                    DocumentType.HOSPITAL_MCD to CdrClientConfig.Connector.DocTypeFolders().apply { targetFolder = targetFolder0 },
-                    DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply { targetFolder = targetFolder0 },
-                    DocumentType.NOTIFICATION to CdrClientConfig.Connector.DocTypeFolders().apply { targetFolder = targetFolder0 },
+                    DocumentType.CONTAINER to CdrClientConfig.Connector.DocTypeFolders(targetFolder = targetFolder0),
+                    DocumentType.CREDIT to CdrClientConfig.Connector.DocTypeFolders(targetFolder = targetFolder0),
+                    DocumentType.FORM to CdrClientConfig.Connector.DocTypeFolders(targetFolder = targetFolder0),
+                    DocumentType.HOSPITAL_MCD to CdrClientConfig.Connector.DocTypeFolders(targetFolder = targetFolder0),
+                    DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(targetFolder = targetFolder0),
+                    DocumentType.NOTIFICATION to CdrClientConfig.Connector.DocTypeFolders(targetFolder = targetFolder0),
                 )
             ),
             createConnector(
                 "connectorId", targetFolder1, sourceFolder1, FORUM_DATENAUSTAUSCH_MEDIA_TYPE, CdrClientConfig.Mode.PRODUCTION,
                 mapOf(
-                    DocumentType.CONTAINER to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = sourceFolder2.resolve("sub") },
-                    DocumentType.CREDIT to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = sourceFolder2.resolve("sub1") },
-                    DocumentType.FORM to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = sourceFolder2.resolve("sub2") },
-                    DocumentType.HOSPITAL_MCD to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = sourceFolder2.resolve("sub3") },
-                    DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = sourceFolder2.resolve("sub4") },
-                    DocumentType.NOTIFICATION to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = sourceFolder2.resolve("sub5") },
+                    DocumentType.CONTAINER to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = sourceFolder2.resolve("sub")),
+                    DocumentType.CREDIT to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = sourceFolder2.resolve("sub1")),
+                    DocumentType.FORM to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = sourceFolder2.resolve("sub2")),
+                    DocumentType.HOSPITAL_MCD to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = sourceFolder2.resolve("sub3")),
+                    DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = sourceFolder2.resolve("sub4")),
+                    DocumentType.NOTIFICATION to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = sourceFolder2.resolve("sub5")),
                 )
             ),
             createConnector("connectorId2", targetFolder2, sourceFolder2, FORUM_DATENAUSTAUSCH_MEDIA_TYPE, CdrClientConfig.Mode.TEST),
@@ -469,14 +470,14 @@ class CdrClientConfigTest {
             mode: CdrClientConfig.Mode,
             typeFolders: Map<DocumentType, CdrClientConfig.Connector.DocTypeFolders> = emptyMap()
         ): CdrClientConfig.Connector {
-            return CdrClientConfig.Connector().apply {
-                this.connectorId = connectorId
-                this.targetFolder = targetFolder
-                this.sourceFolder = sourceFolder
-                this.contentType = contentType
-                this.mode = mode
-                this.docTypeFolders = typeFolders
-            }
+            return CdrClientConfig.Connector(
+                connectorId = connectorId,
+                targetFolder = targetFolder,
+                sourceFolder = sourceFolder,
+                contentType = contentType,
+                mode = mode,
+                docTypeFolders = typeFolders,
+            )
         }
 
         private fun createDocTypeFolders(
@@ -484,10 +485,10 @@ class CdrClientConfigTest {
             sourceFolder: Path?,
             documentType: DocumentType = DocumentType.INVOICE
         ): Map<DocumentType, CdrClientConfig.Connector.DocTypeFolders> {
-            return mapOf(documentType to CdrClientConfig.Connector.DocTypeFolders().apply {
-                this.targetFolder = targetFolder
-                if (sourceFolder != null) this.sourceFolder = sourceFolder
-            })
+            return mapOf(documentType to CdrClientConfig.Connector.DocTypeFolders(
+                targetFolder = targetFolder,
+                sourceFolder = sourceFolder,
+            ))
         }
     }
 

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/config/FileBusyTesterTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/config/FileBusyTesterTest.kt
@@ -18,7 +18,7 @@ import java.time.Duration
 import kotlin.io.path.createFile
 import kotlin.io.path.writeText
 
-class FileBusyTesterTest {
+internal class FileBusyTesterTest {
 
     @TempDir
     private lateinit var tempDir: Path

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/CdrApiClientTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/CdrApiClientTest.kt
@@ -38,7 +38,7 @@ import kotlin.io.path.writeText
     properties = [
         "spring.main.lazy-initialization=true",
         "spring.jmx.enabled=false",
-        "client.idp-credentials.renew-credential-at-startup=false",
+        "client.idp-credentials.renew-credential=false",
         "client.retry-template.retries=4",
         "client.retry-template.initial-delay=10ms",
         "client.retry-template.multiplier=1.1",
@@ -48,7 +48,7 @@ import kotlin.io.path.writeText
 @ActiveProfiles("test", "noPollingUploadScheduler", "noEventTriggerUploadScheduler", "noDownloadScheduler")
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @Tag("integration-test")
-class CdrApiClientTest {
+internal class CdrApiClientTest {
 
     @SpykBean
     private lateinit var config: CdrClientConfig
@@ -66,19 +66,19 @@ class CdrApiClientTest {
         apiServerMock = MockWebServer()
         apiServerMock.start()
 
-        every { config.credentialApi } returns CdrClientConfig.Endpoint().apply {
-            scheme = "http"
-            host = apiServerMock.hostName
-            port = apiServerMock.port
-            basePath = "client-credentials"
-        }
+        every { config.credentialApi } returns CdrClientConfig.Endpoint(
+            scheme = "http",
+            host = apiServerMock.hostName,
+            port = apiServerMock.port,
+            basePath = "client-credentials",
+        )
 
-        every { config.cdrApi } returns CdrClientConfig.Endpoint().apply {
-            scheme = "http"
-            host = apiServerMock.hostName
-            port = apiServerMock.port
-            basePath = "documents"
-        }
+        every { config.cdrApi } returns CdrClientConfig.Endpoint(
+            scheme = "http",
+            host = apiServerMock.hostName,
+            port = apiServerMock.port,
+            basePath = "documents",
+        )
     }
 
     @AfterEach

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ClientSecretRenewalServiceConfigurationTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ClientSecretRenewalServiceConfigurationTest.kt
@@ -18,12 +18,12 @@ import java.nio.file.Path
     properties = [
         "spring.main.lazy-initialization=true",
         "spring.jmx.enabled=false",
-        "client.idp-credentials.renew-credential-at-startup=false",
+        "client.idp-credentials.renew-credential=false",
     ]
 )
 @ActiveProfiles("test", "noPollingUploadScheduler", "noEventTriggerUploadScheduler", "noDownloadScheduler")
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
-class ClientSecretRenewalServiceConfigurationTest {
+internal class ClientSecretRenewalServiceConfigurationTest {
 
     @Value("\${client.idp-credentials.client-secret}")
     private lateinit var clientSecret: String
@@ -39,7 +39,7 @@ class ClientSecretRenewalServiceConfigurationTest {
                     "property path in `com.swisscom.health.des.cdr.client.handler.ClientSecretRenewalService` and its unit test. Once all is done, amend " +
                     "the path in this test."
         )
-        assertTrue(config.idpCredentials.clientSecret == clientSecret)
+        assertTrue(config.idpCredentials.clientSecret.value == clientSecret)
         assertTrue(clientSecret == "test-client-secret")
     }
 

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ClientSecretRenewalServiceTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ClientSecretRenewalServiceTest.kt
@@ -1,41 +1,21 @@
 package com.swisscom.health.des.cdr.client.handler
 
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
-import com.swisscom.health.des.cdr.client.handler.ClientSecretRenewalService.Companion.CLIENT_PROPERTY
-import com.swisscom.health.des.cdr.client.handler.ClientSecretRenewalService.Companion.CLIENT_SECRET_PROPERTY
-import com.swisscom.health.des.cdr.client.handler.ClientSecretRenewalService.Companion.CLIENT_SECRET_PROPERTY_PATH
-import com.swisscom.health.des.cdr.client.handler.ClientSecretRenewalService.Companion.IDP_CREDENTIALS_PROPERTY
+import com.swisscom.health.des.cdr.client.config.CdrClientConfig
 import io.micrometer.tracing.Tracer
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.junit5.MockKExtension.CheckUnnecessaryStub
-import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.api.io.TempDir
-import org.springframework.boot.env.OriginTrackedMapPropertySource
-import org.springframework.boot.origin.Origin
-import org.springframework.boot.origin.TextResourceOrigin
-import org.springframework.context.ConfigurableApplicationContext
-import org.springframework.core.env.MutablePropertySources
-import org.springframework.core.io.FileSystemResource
-import java.nio.file.Path
-import kotlin.io.path.createFile
-import kotlin.io.path.readText
-import kotlin.io.path.writeText
 
 @ExtendWith(MockKExtension::class)
 @CheckUnnecessaryStub
-class ClientSecretRenewalServiceTest {
-
-    @TempDir
-    lateinit var tempConfigDir: Path
+internal class ClientSecretRenewalServiceTest {
 
     @MockK
     private lateinit var tracer: Tracer
@@ -44,14 +24,18 @@ class ClientSecretRenewalServiceTest {
     private lateinit var cdrApiClient: CdrApiClient
 
     @MockK
-    private lateinit var applicationContext: ConfigurableApplicationContext
+    private lateinit var config: CdrClientConfig
+
+    @MockK
+    private lateinit var configurationWriter: ConfigurationWriter
 
     private lateinit var clientSecretRenewalService: ClientSecretRenewalService
 
     @BeforeEach
     fun setup() {
         clientSecretRenewalService = ClientSecretRenewalService(
-            context = applicationContext,
+            config = config,
+            configurationWriter = configurationWriter,
             cdrApiClient = cdrApiClient,
             tracer = tracer
         )
@@ -59,173 +43,31 @@ class ClientSecretRenewalServiceTest {
 
     @Test
     fun `no known origin for secret property should yield error`() {
-        every { applicationContext.environment.propertySources } returns MutablePropertySources()
+        every {configurationWriter.isWritableConfigurationItem(any<String>())} returns ConfigurationWriter.ConfigLookupResult.NotFound
 
         val result: ClientSecretRenewalService.RenewClientSecretResult = clientSecretRenewalService.renewClientSecret()
 
-        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.RenewError>(result) { "Expected RenewError, but got $result" }
-        assertEquals("No origin found for client secret `$CLIENT_SECRET_PROPERTY_PATH`", result.cause.message)
+        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.Failure>(result) { "Expected RenewError, but got $result" }
 
         // verify we did not call the credential renewal API
-        confirmVerified(cdrApiClient)
-    }
-
-    @Test
-    fun `multiple known origins for secret property should yield error`() {
-        val propOrigin1 = mockk<Origin>()
-        val propOrigin2 = mockk<Origin>()
-        val propSource1 = mockk<OriginTrackedMapPropertySource>()
-        val propSource2 = mockk<OriginTrackedMapPropertySource>()
-        every { propSource1.getOrigin(CLIENT_SECRET_PROPERTY_PATH) } returns propOrigin1
-        every { propSource2.getOrigin(CLIENT_SECRET_PROPERTY_PATH) } returns propOrigin2
-        val propertySources = MutablePropertySources().apply {
-            addLast(propSource1)
-            addLast(propSource2)
-        }
-        every { applicationContext.environment.propertySources } returns propertySources
-
-        val result: ClientSecretRenewalService.RenewClientSecretResult = clientSecretRenewalService.renewClientSecret()
-
-        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.RenewError>(result) { "Expected RenewError, but got $result" }
-        assertEquals("Multiple origins found for client secret `$CLIENT_SECRET_PROPERTY_PATH`: '${setOf(propOrigin1, propOrigin2)}'", result.cause.message)
-
-        // verify we did not call the credential renewal API
-        confirmVerified(cdrApiClient)
-    }
-
-    @Test
-    fun `a client secret origin that is not a text resource should fail`() {
-        val propOrigin = mockk<Origin>()
-        val propSource = mockk<OriginTrackedMapPropertySource>()
-        every { propSource.getOrigin(CLIENT_SECRET_PROPERTY_PATH) } returns propOrigin
-        val propertySources = MutablePropertySources().apply {
-            addLast(propSource)
-        }
-        every { applicationContext.environment.propertySources } returns propertySources
-
-        val result: ClientSecretRenewalService.RenewClientSecretResult = clientSecretRenewalService.renewClientSecret()
-
-        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.RenewError>(result) { "Expected RenewError, but got $result" }
-        assertEquals("Don't know how to get file resource for origin type: '${propOrigin::class.qualifiedName}'", result.cause.message)
-
-        // verify we did not call the credential renewal API
-        confirmVerified(cdrApiClient)
-    }
-
-    @Test
-    fun `if the client secret origin resource is not a writable file then renewal should fail`() {
-        val propOrigin = mockk<TextResourceOrigin>()
-        every { propOrigin.resource } returns FileSystemResource(tempConfigDir) // directory -> fails `isWritable` check that requires resource to be a file
-        val propSource = mockk<OriginTrackedMapPropertySource>()
-        every { propSource.getOrigin(CLIENT_SECRET_PROPERTY_PATH) } returns propOrigin
-        val propertySources = MutablePropertySources().apply {
-            addLast(propSource)
-        }
-        every { applicationContext.environment.propertySources } returns propertySources
-
-        val result: ClientSecretRenewalService.RenewClientSecretResult = clientSecretRenewalService.renewClientSecret()
-
-        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.RenewError>(result) { "Expected RenewError, but got $result" }
-        assertEquals("Resource is not writable: '${FileSystemResource(tempConfigDir)}'", result.cause.message)
-
-        // verify we did not call the credential renewal API
-        confirmVerified(cdrApiClient)
-    }
-
-    @Test
-    fun `if the client secret origin resource is of an unknown file type then renewal should fail`() {
-        val configFile = tempConfigDir.resolve("unknown_config_format.toml").apply { createFile() }
-        val propOrigin = mockk<TextResourceOrigin>()
-        val fileSystemResource = FileSystemResource(configFile)
-        every { propOrigin.resource } returns fileSystemResource
-        val propSource = mockk<OriginTrackedMapPropertySource>()
-        every { propSource.getOrigin(CLIENT_SECRET_PROPERTY_PATH) } returns propOrigin
-        val propertySources = MutablePropertySources().apply {
-            addLast(propSource)
-        }
-        every { applicationContext.environment.propertySources } returns propertySources
-
-        val result: ClientSecretRenewalService.RenewClientSecretResult = clientSecretRenewalService.renewClientSecret()
-
-        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.RenewError>(result) { "Expected RenewError, but got $result" }
-        assertEquals("Don't know file type for extension: '${fileSystemResource.file.extension}'; resource: '$fileSystemResource'", result.cause.message)
-
-        // verify we did not call the credential renewal API
-        confirmVerified(cdrApiClient)
-    }
-
-    @Test
-    fun `successful renewal of client secret in a YAML file`() {
-        val configFile = tempConfigDir.resolve("unknown_config_format.yaml").apply {
-            createFile()
-            writeText(CLIENT_SECRET_YAML)
-        }
-        val propOrigin = mockk<TextResourceOrigin>()
-        val fileSystemResource = FileSystemResource(configFile)
-        every { propOrigin.resource } returns fileSystemResource
-        val propSource = mockk<OriginTrackedMapPropertySource>()
-        every { propSource.getOrigin(CLIENT_SECRET_PROPERTY_PATH) } returns propOrigin
-        val propertySources = MutablePropertySources().apply {
-            addLast(propSource)
-        }
-        every { applicationContext.environment.propertySources } returns propertySources
-        every { tracer.currentSpan() } returns null
-        every { cdrApiClient.renewClientCredential(any<String>()) } returns CdrApiClient.RenewClientSecretResult.Success(clientId = "foo", clientSecret = "bar")
-
-        val result: ClientSecretRenewalService.RenewClientSecretResult = clientSecretRenewalService.renewClientSecret()
-
-        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.Success>(result) { "Expected Success, but got $result" }
-        val newPassword: String = YAMLMapper().run {
-            readTree(result.secretSource.inputStream).run {
-                get(CLIENT_PROPERTY)
-                    .get(IDP_CREDENTIALS_PROPERTY)
-                    .get(CLIENT_SECRET_PROPERTY)
-                    .textValue()
-            }
-        }
-        assertEquals("bar", newPassword)
-
-        // verify we called the credential renewal API
-        verify(exactly = 1) { cdrApiClient.renewClientCredential(any<String>()) }
         confirmVerified(cdrApiClient)
     }
 
     @Test
     fun `failing call to credential API should leave config file unchanged`() {
-        val configFile = tempConfigDir.resolve("unknown_config_format.yaml").apply {
-            createFile()
-            writeText(CLIENT_SECRET_YAML)
-        }
-        val propOrigin = mockk<TextResourceOrigin>()
-        val fileSystemResource = FileSystemResource(configFile)
-        every { propOrigin.resource } returns fileSystemResource
-        val propSource = mockk<OriginTrackedMapPropertySource>()
-        every { propSource.getOrigin(CLIENT_SECRET_PROPERTY_PATH) } returns propOrigin
-        val propertySources = MutablePropertySources().apply {
-            addLast(propSource)
-        }
-        every { applicationContext.environment.propertySources } returns propertySources
+        every { configurationWriter.isWritableConfigurationItem(any<String>()) } returns ConfigurationWriter.ConfigLookupResult.Writable
         every { tracer.currentSpan() } returns null
         every { cdrApiClient.renewClientCredential(any<String>()) } returns CdrApiClient.RenewClientSecretResult.RenewHttpErrorResponse(500, "API call failed")
 
         val result: ClientSecretRenewalService.RenewClientSecretResult = clientSecretRenewalService.renewClientSecret()
 
-        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.RenewError>(result) { "Expected RenewError, but got $result" }
-        assertEquals("http error; status code: 500", result.cause.message)
+        assertInstanceOf<ClientSecretRenewalService.RenewClientSecretResult.Failure>(result) { "Expected RenewError, but got $result" }
 
         // verify we called the credential renewal API
         verify(exactly = 1) { cdrApiClient.renewClientCredential(any<String>()) }
         confirmVerified(cdrApiClient)
-        // config file contents must not be changed
-        assertEquals(CLIENT_SECRET_YAML, configFile.readText())
+        // verify we did not call the configuration writer's update method
+        verify(exactly = 0) { configurationWriter.updateClientServiceConfiguration(any<CdrClientConfig>()) }
     }
 
-    private companion object {
-        @JvmStatic
-        private val CLIENT_SECRET_YAML = """
-            $CLIENT_PROPERTY:
-              $IDP_CREDENTIALS_PROPERTY:
-                $CLIENT_SECRET_PROPERTY: "Placeholder_secret"
-        """.trimIndent()
-    }
 }

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigurationWriterTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigurationWriterTest.kt
@@ -1,0 +1,249 @@
+package com.swisscom.health.des.cdr.client.handler
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.swisscom.health.des.cdr.client.config.CdrClientConfig
+import com.swisscom.health.des.cdr.client.config.ClientSecret
+import com.swisscom.health.des.cdr.client.config.FileSynchronization
+import com.swisscom.health.des.cdr.client.config.IdpCredentials
+import com.swisscom.health.des.cdr.client.config.LastUpdatedAt
+import com.swisscom.health.des.cdr.client.config.RenewCredential
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.junit5.MockKExtension.CheckUnnecessaryStub
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
+import org.springframework.boot.env.OriginTrackedMapPropertySource
+import org.springframework.boot.origin.TextResourceOrigin
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.MutablePropertySources
+import org.springframework.core.io.FileSystemResource
+import org.springframework.http.MediaType
+import org.springframework.util.unit.DataSize
+import java.net.URL
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+import kotlin.io.path.createFile
+import kotlin.io.path.inputStream
+import kotlin.io.path.writeText
+
+@ExtendWith(MockKExtension::class)
+@CheckUnnecessaryStub
+class ConfigurationWriterTest {
+
+    @TempDir
+    lateinit var tempConfigDir: Path
+
+    @MockK
+    private lateinit var applicationContext: ConfigurableApplicationContext
+
+    private lateinit var config: CdrClientConfig
+
+    private lateinit var configurationWriter: ConfigurationWriter
+
+
+    @BeforeEach
+    fun setup() {
+        config = CdrClientConfig(
+            fileSynchronizationEnabled = FileSynchronization.ENABLED,
+            customer = listOf(
+                CdrClientConfig.Connector(
+                    connectorId = "1",
+                    targetFolder = EMPTY_PATH,
+                    sourceFolder = EMPTY_PATH,
+                    contentType = MediaType.APPLICATION_OCTET_STREAM,
+                    sourceArchiveEnabled = false,
+                    sourceArchiveFolder = EMPTY_PATH,
+                    sourceErrorFolder = EMPTY_PATH,
+                    mode = CdrClientConfig.Mode.PRODUCTION,
+                    docTypeFolders = emptyMap()
+                )
+            ),
+            cdrApi = CdrClientConfig.Endpoint(
+                scheme = "https",
+                host = "localhost",
+                port = 8080,
+                basePath = "/"
+            ),
+            filesInProgressCacheSize = DataSize.ofMegabytes(1L),
+            idpCredentials = IdpCredentials(
+                tenantId = "",
+                clientId = "",
+                clientSecret = ClientSecret(""),
+                scopes = emptyList(),
+                renewCredential = RenewCredential.ENABLED,
+                maxCredentialAge = Duration.ofDays(30),
+                lastCredentialRenewalTime = LastUpdatedAt(Instant.now()),
+            ),
+            idpEndpoint = URL("http://localhost:8080"),
+            localFolder = EMPTY_PATH,
+            pullThreadPoolSize = 1,
+            pushThreadPoolSize = 1,
+            retryDelay = emptyList(),
+            scheduleDelay = Duration.ofSeconds(1L),
+            credentialApi = CdrClientConfig.Endpoint(
+                scheme = "https",
+                host = "localhost",
+                port = 8080,
+                basePath = "/"
+            ),
+            retryTemplate = CdrClientConfig.RetryTemplateConfig(
+                retries = 1,
+                initialDelay = Duration.ofSeconds(1L),
+                maxDelay = Duration.ofSeconds(1L),
+                multiplier = 2.0
+            ),
+            fileBusyTestInterval = Duration.ofSeconds(1L),
+            fileBusyTestTimeout = Duration.ofSeconds(1L),
+            fileBusyTestStrategy = CdrClientConfig.FileBusyTestStrategy.NEVER_BUSY
+        )
+
+        configurationWriter = ConfigurationWriter(
+            currentConfig = config,
+            context = applicationContext,
+        )
+    }
+
+    @Test
+    fun `no known origin for property should succeed - to be changed once rollback strategy is implemented`() {
+        every { applicationContext.environment.propertySources } returns MutablePropertySources()
+
+        val result = configurationWriter.updateClientServiceConfiguration(config.copy(fileSynchronizationEnabled = FileSynchronization.DISABLED))
+
+        assertInstanceOf<ConfigurationWriter.Result.Success>(result) { "Expected failure, but got $result" }
+    }
+
+    @Test
+    fun `if the client secret origin resource is not a writable file then renewal should succeed - to be changed once rollback strategy is implemented`() {
+        val propOrigin = mockk<TextResourceOrigin>()
+        every { propOrigin.resource } returns FileSystemResource(tempConfigDir) // directory -> fails `isWritable` check that requires resource to be a file
+        val propSource = mockk<OriginTrackedMapPropertySource>()
+        every { propSource.getOrigin("client.file-synchronization-enabled") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.renew-credential") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.last-credential-renewal-time") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.client-secret") } returns propOrigin
+        val propertySources = MutablePropertySources().apply {
+            addLast(propSource)
+        }
+        every { applicationContext.environment.propertySources } returns propertySources
+
+        val result = configurationWriter.updateClientServiceConfiguration(config.copy(fileSynchronizationEnabled = FileSynchronization.DISABLED))
+
+        assertInstanceOf<ConfigurationWriter.Result.Success>(result) { "Expected Success, but got $result" }
+    }
+
+    @Test
+    fun `if the client secret origin resource is of an unknown file type then renewal should succeed - to be changed once rollback strategy is implemented`() {
+        val configFile = tempConfigDir.resolve("unknown_config_format.toml").apply { createFile() }
+        val propOrigin = mockk<TextResourceOrigin>()
+        val fileSystemResource = FileSystemResource(configFile)
+        every { propOrigin.resource } returns fileSystemResource
+        val propSource = mockk<OriginTrackedMapPropertySource>()
+        every { propSource.getOrigin("client.file-synchronization-enabled") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.renew-credential") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.last-credential-renewal-time") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.client-secret") } returns propOrigin
+        val propertySources = MutablePropertySources().apply {
+            addLast(propSource)
+        }
+        every { applicationContext.environment.propertySources } returns propertySources
+
+        val result = configurationWriter.updateClientServiceConfiguration(config.copy(fileSynchronizationEnabled = FileSynchronization.DISABLED))
+
+        assertInstanceOf<ConfigurationWriter.Result.Success>(result) { "Expected Success, but got $result" }
+    }
+
+    @Test
+    fun `successful renewal of client secret in a YAML file`() {
+        val configFile = tempConfigDir.resolve("unknown_config_format.yaml").apply {
+            createFile()
+            writeText(FILE_SYNC_YAML)
+        }
+        val propOrigin = mockk<TextResourceOrigin>()
+        val fileSystemResource = FileSystemResource(configFile)
+        every { propOrigin.resource } returns fileSystemResource
+        val propSource = mockk<OriginTrackedMapPropertySource>()
+        every { propSource.getOrigin("client.file-synchronization-enabled") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.renew-credential") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.last-credential-renewal-time") } returns propOrigin
+        every { propSource.getOrigin("client.idp-credentials.client-secret") } returns propOrigin
+        val propertySources = MutablePropertySources().apply {
+            addLast(propSource)
+        }
+        every { applicationContext.environment.propertySources } returns propertySources
+
+        val result = configurationWriter.updateClientServiceConfiguration(config.copy(fileSynchronizationEnabled = FileSynchronization.DISABLED))
+
+        assertInstanceOf<ConfigurationWriter.Result.Success>(result) { "Expected Success, but got $result" }
+        val newFileSyncValue = YAMLMapper().run {
+            readTree(configFile.inputStream()).run {
+                get("client")
+                    .get("file-synchronization-enabled")
+                    .booleanValue()
+            }
+        }
+        assertEquals(FileSynchronization.DISABLED.value, newFileSyncValue)
+    }
+
+    @Test
+    fun `multiple known origins for property should update first in list`() {
+        val configFile = tempConfigDir.resolve("unknown_config_format.yaml").apply {
+            createFile()
+            writeText(FILE_SYNC_YAML)
+        }
+
+        val propOrigin1 = mockk<TextResourceOrigin>()
+        val propOrigin2 = mockk<TextResourceOrigin>()
+        val fileSystemResource = FileSystemResource(configFile)
+        every { propOrigin1.resource } returns fileSystemResource
+        val propSource1 = mockk<OriginTrackedMapPropertySource>()
+        val propSource2 = mockk<OriginTrackedMapPropertySource>()
+        every { propSource1.getOrigin("client.file-synchronization-enabled") } returns propOrigin1
+        every { propSource2.getOrigin("client.file-synchronization-enabled") } returns propOrigin2
+        every { propSource1.getOrigin("client.idp-credentials.renew-credential") } returns propOrigin1
+        every { propSource2.getOrigin("client.idp-credentials.renew-credential") } returns null
+        every { propSource1.getOrigin("client.idp-credentials.last-credential-renewal-time") } returns propOrigin1
+        every { propSource2.getOrigin("client.idp-credentials.last-credential-renewal-time") } returns null
+        every { propSource1.getOrigin("client.idp-credentials.client-secret") } returns propOrigin1
+        every { propSource2.getOrigin("client.idp-credentials.client-secret") } returns null
+        val propertySources = MutablePropertySources().apply {
+            addLast(propSource1)
+            addLast(propSource2)
+        }
+        every { applicationContext.environment.propertySources } returns propertySources
+
+        val result = configurationWriter.updateClientServiceConfiguration(config.copy(fileSynchronizationEnabled = FileSynchronization.DISABLED))
+
+        assertInstanceOf<ConfigurationWriter.Result.Success>(result) { "Expected Success, but got $result" }
+        val newFileSyncValue = YAMLMapper().run {
+            readTree(configFile.inputStream()).run {
+                get("client")
+                    .get("file-synchronization-enabled")
+                    .booleanValue()
+            }
+        }
+        assertEquals(FileSynchronization.DISABLED.value, newFileSyncValue)
+
+        // make sure no attempt was made to access the second property source
+        verify(exactly = 0) { propOrigin2.resource }
+    }
+
+    companion object {
+        @JvmStatic
+        private val EMPTY_PATH = Path.of("")
+
+        @JvmStatic
+        private val FILE_SYNC_YAML = """
+            client:
+               file-synchronization-enabled: true
+        """.trimIndent()
+    }
+
+}

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/EventPushFileHandlingTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/EventPushFileHandlingTest.kt
@@ -52,7 +52,7 @@ import kotlin.io.path.walk
     properties = [
         "spring.main.lazy-initialization=true",
         "spring.jmx.enabled=false",
-        "client.idp-credentials.renew-credential-at-startup=false",
+        "client.idp-credentials.renew-credential=false",
     ]
 )
 // only test filesystem event handling, no polling
@@ -86,20 +86,20 @@ internal class EventPushFileHandlingTest {
         val sourceFolder0 = tmpDir.resolve(sourceDirectory).also { it.createDirectories() }
         val targetFolder0 = tmpDir.resolve(targetDirectory).also { it.createDirectories() }
 
-        every { config.cdrApi } returns CdrClientConfig.Endpoint().apply {
-            host = cdrServiceMock.hostName
-            basePath = "documents"
-            scheme = "http"
-            port = cdrServiceMock.port
-        }
+        every { config.cdrApi } returns CdrClientConfig.Endpoint(
+            host = cdrServiceMock.hostName,
+            basePath = "documents",
+            scheme = "http",
+            port = cdrServiceMock.port,
+        )
         every { config.customer } returns listOf(
-            CdrClientConfig.Connector().apply {
-                connectorId = "2345"
-                targetFolder = targetFolder0
-                sourceFolder = sourceFolder0
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-            }
+            CdrClientConfig.Connector(
+                connectorId = "2345",
+                targetFolder = targetFolder0,
+                sourceFolder = sourceFolder0,
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+            )
         )
 
         val resultMock: CompletableFuture<IAuthenticationResult> = mockk()

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/FileHandlingBaseTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/FileHandlingBaseTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import kotlin.io.path.deleteIfExists
 
-class FileHandlingBaseTest {
+internal class FileHandlingBaseTest {
 
     @Test
     fun `test non writable folder`() {

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/PollingPushFileHandlingTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/PollingPushFileHandlingTest.kt
@@ -54,7 +54,7 @@ import kotlin.io.path.walk
     properties = [
         "spring.main.lazy-initialization=true",
         "spring.jmx.enabled=false",
-        "client.idp-credentials.renew-credential-at-startup=false",
+        "client.idp-credentials.renew-credential=false",
     ]
 )
 // only test polling, not filesystem event handling
@@ -94,20 +94,20 @@ internal class PollingPushFileHandlingTest {
         val targetFolder0 = tmpDir.resolve(targetDirectory).also { it.createDirectories() }
 
         every { config.localFolder } returns inflightDir
-        every { config.cdrApi } returns CdrClientConfig.Endpoint().apply {
-            host = cdrServiceMock.hostName
-            basePath = "documents"
-            scheme = "http"
-            port = cdrServiceMock.port
-        }
+        every { config.cdrApi } returns CdrClientConfig.Endpoint(
+            host = cdrServiceMock.hostName,
+            basePath = "documents",
+            scheme = "http",
+            port = cdrServiceMock.port,
+        )
         every { config.customer } returns listOf(
-            CdrClientConfig.Connector().apply {
-                connectorId = "2345"
-                targetFolder = targetFolder0
-                sourceFolder = sourceFolder0
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-            }
+            CdrClientConfig.Connector(
+                connectorId = "2345",
+                targetFolder = targetFolder0,
+                sourceFolder = sourceFolder0,
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+            )
         )
 
         val resultMock: CompletableFuture<IAuthenticationResult> = mockk()
@@ -177,15 +177,15 @@ internal class PollingPushFileHandlingTest {
         val sourceFolder0 = tmpDir.resolve(sourceDirectory)
         val targetFolder0 = tmpDir.resolve(targetDirectory)
         every { config.customer } returns listOf(
-            CdrClientConfig.Connector().apply {
-                connectorId = "2345"
-                targetFolder = targetFolder0
-                sourceFolder = sourceFolder0
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-                sourceArchiveEnabled = true
-                sourceArchiveFolder = relativeArchiveFolder
-            }
+            CdrClientConfig.Connector(
+                connectorId = "2345",
+                targetFolder = targetFolder0,
+                sourceFolder = sourceFolder0,
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+                sourceArchiveEnabled = true,
+                sourceArchiveFolder = relativeArchiveFolder,
+            )
         )
 
         val mockResponse = MockResponse()
@@ -228,16 +228,16 @@ internal class PollingPushFileHandlingTest {
         val targetFolder0 = tmpDir.resolve(targetDirectory)
         val invoiceSourceFolder = sourceFolder0.resolve("invoice").also { it.createDirectories() }
         every { config.customer } returns listOf(
-            CdrClientConfig.Connector().apply {
-                connectorId = "2345"
-                targetFolder = targetFolder0
-                sourceFolder = sourceFolder0
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-                sourceArchiveEnabled = true
-                sourceArchiveFolder = relativeArchiveFolder
-                docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = invoiceSourceFolder })
-            }
+            CdrClientConfig.Connector(
+                connectorId = "2345",
+                targetFolder = targetFolder0,
+                sourceFolder = sourceFolder0,
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+                sourceArchiveEnabled = true,
+                sourceArchiveFolder = relativeArchiveFolder,
+                docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = invoiceSourceFolder)),
+            )
         )
 
         val mockResponse = MockResponse()
@@ -281,16 +281,16 @@ internal class PollingPushFileHandlingTest {
         val targetFolder0 = tmpDir.resolve(targetDirectory)
         val invoiceSourceFolder = sourceFolder0.resolve("invoice").also { it.createDirectories() }
         every { config.customer } returns listOf(
-            CdrClientConfig.Connector().apply {
-                connectorId = "2345"
-                targetFolder = targetFolder0
-                sourceFolder = sourceFolder0
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-                sourceArchiveEnabled = true
-                sourceArchiveFolder = absoluteArchiveFolder
-                docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = invoiceSourceFolder })
-            }
+            CdrClientConfig.Connector(
+                connectorId = "2345",
+                targetFolder = targetFolder0,
+                sourceFolder = sourceFolder0,
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+                sourceArchiveEnabled = true,
+                sourceArchiveFolder = absoluteArchiveFolder,
+                docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = invoiceSourceFolder)),
+            )
         )
 
         val mockResponse = MockResponse()
@@ -399,14 +399,14 @@ internal class PollingPushFileHandlingTest {
         val sourceFolder0 = tmpDir.resolve(sourceDirectory)
         val targetFolder0 = tmpDir.resolve(targetDirectory)
         every { config.customer } returns listOf(
-            CdrClientConfig.Connector().apply {
-                connectorId = "2345"
-                targetFolder = targetFolder0
-                sourceFolder = sourceFolder0
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-                sourceErrorFolder = relativeErrorFolder
-            }
+            CdrClientConfig.Connector(
+                connectorId = "2345",
+                targetFolder = targetFolder0,
+                sourceFolder = sourceFolder0,
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+                sourceErrorFolder = relativeErrorFolder,
+            )
         )
 
         val mockResponse = MockResponse()
@@ -457,15 +457,15 @@ internal class PollingPushFileHandlingTest {
         val invoiceSourceFolder = sourceFolder0.resolve("invoice").also { it.createDirectories() }
 
         every { config.customer } returns listOf(
-            CdrClientConfig.Connector().apply {
-                connectorId = "2345"
-                targetFolder = targetFolder0
-                sourceFolder = sourceFolder0
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-                sourceErrorFolder = absoluteErrorFolder
-                docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = invoiceSourceFolder })
-            }
+            CdrClientConfig.Connector(
+                connectorId = "2345",
+                targetFolder = targetFolder0,
+                sourceFolder = sourceFolder0,
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+                sourceErrorFolder = absoluteErrorFolder,
+                docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = invoiceSourceFolder)),
+            )
         )
 
         val mockResponse = MockResponse()
@@ -517,15 +517,15 @@ internal class PollingPushFileHandlingTest {
         val invoiceSourceFolder = sourceFolder0.resolve("invoice").also { it.createDirectories() }
 
         every { config.customer } returns listOf(
-            CdrClientConfig.Connector().apply {
-                connectorId = "2345"
-                targetFolder = targetFolder0
-                sourceFolder = sourceFolder0
-                contentType = forumDatenaustauschMediaType
-                mode = CdrClientConfig.Mode.TEST
-                sourceErrorFolder = relativeErrorFolder
-                docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply { sourceFolder = invoiceSourceFolder })
-            }
+            CdrClientConfig.Connector(
+                connectorId = "2345",
+                targetFolder = targetFolder0,
+                sourceFolder = sourceFolder0,
+                contentType = forumDatenaustauschMediaType,
+                mode = CdrClientConfig.Mode.TEST,
+                sourceErrorFolder = relativeErrorFolder,
+                docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(sourceFolder = invoiceSourceFolder))
+            )
         )
 
         val mockResponse = MockResponse()

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/PullFileHandlingTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/PullFileHandlingTest.kt
@@ -84,12 +84,12 @@ internal class PullFileHandlingTest {
         cdrServiceMock.start()
         mockTracer()
 
-        endpoint = CdrClientConfig.Endpoint().apply {
-            host = cdrServiceMock.hostName
-            basePath = "documents"
-            scheme = "http"
-            port = cdrServiceMock.port
-        }
+        endpoint = CdrClientConfig.Endpoint(
+            host = cdrServiceMock.hostName,
+            basePath = "documents",
+            scheme = "http",
+            port = cdrServiceMock.port,
+        )
 
         tmpDir.resolve(targetDirectory).also { it.createDirectories() }
         val inflightDir = tmpDir.resolve(inflightFolder).also { it.createDirectories() }
@@ -138,16 +138,18 @@ internal class PullFileHandlingTest {
 
         val invoiceFolder = tmpDir.resolve("invoice").also { it.createDirectories() }
 
-        val connector = CdrClientConfig.Connector().apply {
-            connectorId = "1-2-3-4"
-            targetFolder = tmpDir.resolve(targetDirectory)
-            sourceFolder = tmpDir.resolve(sourceDirectory)
-            contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8")
-            mode = CdrClientConfig.Mode.PRODUCTION
-            docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply {
-                targetFolder = invoiceFolder
-            })
-        }
+        val connector = CdrClientConfig.Connector(
+            connectorId = "1-2-3-4",
+            targetFolder = tmpDir.resolve(targetDirectory),
+            sourceFolder = tmpDir.resolve(sourceDirectory),
+            contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8"),
+            mode = CdrClientConfig.Mode.PRODUCTION,
+            docTypeFolders = mapOf(
+                DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(
+                    targetFolder = invoiceFolder,
+                )
+            )
+        )
 
         runBlocking {
             pullFileHandling.pullSyncConnector(connector)
@@ -174,16 +176,18 @@ internal class PullFileHandlingTest {
         val invoiceFolder = tmpDir.resolve("invoice").also { it.createDirectories() }
         val targetDir = tmpDir.resolve(targetDirectory)
 
-        val connector = CdrClientConfig.Connector().apply {
-            connectorId = "1-2-3-4"
-            targetFolder = targetDir
-            sourceFolder = tmpDir.resolve(sourceDirectory)
-            contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8")
-            mode = CdrClientConfig.Mode.PRODUCTION
-            docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply {
-                targetFolder = invoiceFolder
-            })
-        }
+        val connector = CdrClientConfig.Connector(
+            connectorId = "1-2-3-4",
+            targetFolder = targetDir,
+            sourceFolder = tmpDir.resolve(sourceDirectory),
+            contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8"),
+            mode = CdrClientConfig.Mode.PRODUCTION,
+            docTypeFolders = mapOf(
+                DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(
+                    targetFolder = invoiceFolder,
+                )
+            )
+        )
 
         runBlocking {
             pullFileHandling.pullSyncConnector(connector)
@@ -210,16 +214,18 @@ internal class PullFileHandlingTest {
         val invoiceFolder = tmpDir.resolve("invoice").also { it.createDirectories() }
         val targetDir = tmpDir.resolve(targetDirectory)
 
-        val connector = CdrClientConfig.Connector().apply {
-            connectorId = "1-2-3-4"
-            targetFolder = targetDir
-            sourceFolder = tmpDir.resolve(sourceDirectory)
-            contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8")
-            mode = CdrClientConfig.Mode.PRODUCTION
-            docTypeFolders = mapOf(DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders().apply {
-                targetFolder = invoiceFolder
-            })
-        }
+        val connector = CdrClientConfig.Connector(
+            connectorId = "1-2-3-4",
+            targetFolder = targetDir,
+            sourceFolder = tmpDir.resolve(sourceDirectory),
+            contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8"),
+            mode = CdrClientConfig.Mode.PRODUCTION,
+            docTypeFolders = mapOf(
+                DocumentType.INVOICE to CdrClientConfig.Connector.DocTypeFolders(
+                    targetFolder = invoiceFolder,
+                )
+            )
+        )
 
         runBlocking {
             pullFileHandling.pullSyncConnector(connector)
@@ -329,13 +335,13 @@ internal class PullFileHandlingTest {
         targetFolder0: Path = tmpDir.resolve(targetDirectory),
         sourceFolder0: Path = tmpDir.resolve(sourceDirectory),
     ): CdrClientConfig.Connector =
-        CdrClientConfig.Connector().apply {
-            connectorId = connectorId0
-            targetFolder = targetFolder0
-            sourceFolder = sourceFolder0
-            contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8")
-            mode = CdrClientConfig.Mode.PRODUCTION
-        }
+        CdrClientConfig.Connector(
+            connectorId = connectorId0,
+            targetFolder = targetFolder0,
+            sourceFolder = sourceFolder0,
+            contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8"),
+            mode = CdrClientConfig.Mode.PRODUCTION,
+        )
 
     private fun enqueueFileResponseWithReportResponse(fileName: String = "dummy.txt") {
         enqueueFileResponse(fileName)

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/installer/InstallerTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/installer/InstallerTest.kt
@@ -69,7 +69,7 @@ internal class InstallerTest {
             configContent.contains("client.idp-credentials.client-secret=clientSecret"),
             "Config file should contain client-secret"
         )
-        assertFalse(configContent.contains("client.idp-credentials.renew-credential-at-startup"), "Config file should not contain renew-credential-at-startup")
+        assertFalse(configContent.contains("client.idp-credentials.renew-credential"), "Config file should not contain renew-credential")
         assertFalse(configContent.contains("client.cdr-api.host"), "Config file should not contain host")
         assertTrue(
             configContent.contains("client.customer[0].connector-id=connectorId"),
@@ -110,8 +110,8 @@ internal class InstallerTest {
             "Config file should contain client-secret"
         )
         assertTrue(
-            configContent.contains("client.idp-credentials.renew-credential-at-startup=false"),
-            "Config file should contain renew-credential-at-startup set to false"
+            configContent.contains("client.idp-credentials.renew-credential=false"),
+            "Config file should contain renew-credential set to false"
         )
         assertTrue(
             configContent.contains("client.idp-credentials.scopes=https://tst.identity.health.swisscom.ch/CdrApi/.default"),

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/scheduling/DocumentDownloadSchedulerTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/scheduling/DocumentDownloadSchedulerTest.kt
@@ -58,13 +58,13 @@ internal class DocumentDownloadSchedulerTest {
         val sourceDir0 = tmpDir.resolve(sourceDirectory).also { it.createDirectories() }
 
         val connector =
-            CdrClientConfig.Connector().apply {
-                connectorId = "1234"
-                targetFolder = targetDir0
-                sourceFolder = sourceDir0
-                contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8")
-                mode = CdrClientConfig.Mode.TEST
-            }
+            CdrClientConfig.Connector(
+                connectorId = "1234",
+                targetFolder = targetDir0,
+                sourceFolder = sourceDir0,
+                contentType = MediaType.parseMediaType("application/forumdatenaustausch+xml;charset=UTF-8"),
+                mode = CdrClientConfig.Mode.TEST,
+            )
         every { config.customer } returns listOf(connector)
         every { config.localFolder } returns inflightDir
         mockTracer()

--- a/cdr-client-service/src/test/resources/application-test.yaml
+++ b/cdr-client-service/src/test/resources/application-test.yaml
@@ -1,10 +1,11 @@
 client:
-  function-key:
   idp-credentials:
+    renew-credential: true
     # if you change this value, you must also change it in the mock-oauth2-server/config.json file and caddy/Caddyfile
     tenant-id: test-tenant-client-id
     client-id: easy-system-test-user-id
     client-secret: test-client-secret
+    last-credential-renewal-time: 1970-01-01T00:00:00Z
     scopes:
       - https://dev.identity.health.swisscom.ch/CdrApi/.default
   local-folder: ${java.io.tmpdir}/cdr_download

--- a/cdr-client-ui/build.gradle.kts
+++ b/cdr-client-ui/build.gradle.kts
@@ -6,18 +6,6 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.conveyor)
-    alias(libs.plugins.detekt)
-}
-
-project.afterEvaluate {
-    // https://github.com/detekt/detekt/issues/6198#issuecomment-2265183695
-    configurations.matching { it.name == "detekt" }.all {
-        resolutionStrategy.eachDependency {
-            if (requested.group == "org.jetbrains.kotlin") {
-                useVersion(io.gitlab.arturbosch.detekt.getSupportedKotlinVersion())
-            }
-        }
-    }
 }
 
 kotlin {

--- a/cdr-client-ui/src/commonMain/composeResources/values/strings.xml
+++ b/cdr-client-ui/src/commonMain/composeResources/values/strings.xml
@@ -21,5 +21,6 @@
     <!-- Tooltips -->
 
     <!-- Error messages -->
-    <string name="error_client_communication">Failed to communicate with the client service.</string>
+    <string name="error_client_communication">Failed to communicate with the client service. Details:\n%1$s</string>
+    <string name="error_client_validation">CDR client reported an error. Details:\n%1$s</string>
 </resources>

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/CdrConfigViewModel.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/CdrConfigViewModel.kt
@@ -5,62 +5,180 @@ import androidx.lifecycle.viewModelScope
 import com.swisscom.health.des.cdr.client.common.DTOs
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.Res
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_client_communication
+import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_client_validation
 import com.swisscom.health.des.cdr.client.ui.data.CdrClientApiClient
-import com.swisscom.health.des.cdr.client.ui.data.ShutdownResult
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
-import org.jetbrains.compose.resources.StringResource
+import kotlinx.coroutines.time.delay
+import java.time.Duration
+import java.time.Instant
 import kotlin.time.Duration.Companion.seconds
 
 private val logger = KotlinLogging.logger {}
 
-data class CdrConfigUiState(
-    val clientServiceStatus: DTOs.StatusResponse.StatusCode = DTOs.StatusResponse.StatusCode.SYNCHRONIZING,
-    val errorKey: StringResource? = null, // should be an ArrayDeque<String>, but I have not figured out how to turn that into an observable state yet
+private typealias ErrorHandler = suspend (Map<String, Any>) -> Unit
+private typealias SuccessHandler<T> = suspend (T) -> Unit
+
+internal data class CdrConfigUiState(
+    val clientServiceStatus: DTOs.StatusResponse.StatusCode = DTOs.StatusResponse.StatusCode.UNKNOWN,
+    val clientServiceConfig: DTOs.CdrClientConfig = DTOs.CdrClientConfig.EMPTY,
+    val errorMessageKey: StringResourceWithArgs? = null, // should be an ArrayDeque<String>, but I have not figured out how to turn that into an observable state yet
 )
 
+/**
+ * ViewModel for the CDR client configuration screen. Unfortunately, the way this works is by creating
+ * side effects on the [CdrConfigUiState]. Changes to the state trigger the recomposition of the UI.
+ */
 internal class CdrConfigViewModel(
     private val cdrClientApiClient: CdrClientApiClient,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CdrConfigUiState())
-    val uiState: StateFlow<CdrConfigUiState> = _uiState.asStateFlow()
+    val uiStateFlow: StateFlow<CdrConfigUiState> = _uiState.asStateFlow()
 
-    fun asyncClientServiceShutdown() {
-        if (SHUTDOWN_GUARD.tryLock()) {
-            viewModelScope.launch {
-                cdrClientApiClient.shutdownClientServiceProcess().let { result ->
-                    when (result) {
-                        is ShutdownResult.Success -> {
-                            _uiState.value = _uiState.value.copy(clientServiceStatus = DTOs.StatusResponse.StatusCode.OFFLINE)
-                        }
+    init {
+        queryClientServiceConfiguration()
+    }
 
-                        is ShutdownResult.Failure -> {
-                            _uiState.value = _uiState.value.copy(errorKey = Res.string.error_client_communication)
-                        }
-                    }
+    var fileSynchronizationEnabled: Boolean
+        get() = _uiState.value.clientServiceConfig.fileSynchronizationEnabled
+        set(value) {
+            setFileSync(value)
+        }
+
+    fun applyClientServiceConfiguration(): Job =
+        viewModelScope.launch {
+            cdrClientApiClient.updateClientServiceConfiguration(_uiState.value.clientServiceConfig).handle { response: DTOs.CdrClientConfig ->
+                _uiState.update {
+                    it.copy(
+                        clientServiceConfig = response,
+                    )
+                }
+                asyncClientServiceRestart().join()
+            }
+        }
+
+    /**
+     * Retrieves the client service configuration from the client service. This is the configuration as it is currently
+     * applied in the client service. This state might differ from the state of the configuration file.
+     */
+    fun queryClientServiceConfiguration(): Job =
+        viewModelScope.launch {
+            cdrClientApiClient.getClientServiceConfiguration().handle { config: DTOs.CdrClientConfig ->
+                _uiState.update {
+                    it.copy(
+                        clientServiceConfig = config
+                    )
                 }
             }
-                .invokeOnCompletion { _ -> SHUTDOWN_GUARD.unlock() }
+        }
+
+    private fun setFileSync(enabled: Boolean) {
+        logger.debug { "setFileSync: $enabled" }
+        _uiState.update {
+            it.copy(
+                clientServiceConfig = it.clientServiceConfig.copy(
+                    fileSynchronizationEnabled = enabled
+                )
+            )
+        }
+    }
+
+    /**
+     * The intention is to restart the client service, but all we have to do is command it to shut down
+     * with the correct reason, which translates into an exit code. It is the responsibility of the
+     * service supervisor process (e.g., `systemd`) to then restart the service.
+     *
+     * Effect: Updates the [uiStateFlow] and sets ths service status to [DTOs.StatusResponse.StatusCode.UNKNOWN].
+     * The status will be updated by the next call to [queryClientServiceStatus]. (Yes, we have a race
+     * condition here.)
+     */
+    fun asyncClientServiceRestart(): Job = asyncClientServiceShutdown()
+
+    /**
+     * Queries the client service status and updates the [uiStateFlow] with the result.
+     */
+    fun queryClientServiceStatus(retryStrategy: CdrClientApiClient.RetryStrategy): Job =
+        viewModelScope.launch {
+            cdrClientApiClient.getClientServiceStatus(retryStrategy).let { status ->
+                _uiState.update {
+                    it.copy(
+                        clientServiceStatus = status
+                    )
+                }
+            }
+        }
+
+    fun clearErrorMessage() =
+        _uiState.update {
+            it.copy(
+                errorMessageKey = null
+            )
+        }
+
+    private fun asyncClientServiceShutdown(): Job =
+        if (SHUTDOWN_GUARD.tryLock()) {
+            viewModelScope.launch {
+                cdrClientApiClient.shutdownClientServiceProcess().handle { response: DTOs.ShutdownResponse ->
+                    // wait to set the client service status on the UI to try minimizing the chances of the status update
+                    // process flipping the status before the service process restarts and temporarily goes offline
+                    val untilStatusUpdateOnUi = Duration.between(Instant.now(), response.shutdownScheduledFor).coerceAtLeast(Duration.ZERO)
+                    delay(untilStatusUpdateOnUi)
+                    _uiState.update {
+                        it.copy(
+                            // set the status to UNKNOWN here and use retries during status update if remote status is OFFLINE,
+                            // hoping the service is back before the retries run out; this way the user sees the state go from
+                            // <state_before_shutdown> to UNKNOWN to <state_after_start>, without ever showing OFFLINE (which
+                            // normally indicates a fatal problem in the service configuration that prevents it from starting)
+                            clientServiceStatus = DTOs.StatusResponse.StatusCode.UNKNOWN
+                        )
+                    }
+                }
+            }.apply {
+                invokeOnCompletion { _ -> SHUTDOWN_GUARD.unlock() }
+            }
         } else {
             logger.debug { "client shutdown is in progress, ignoring command" }
+            Job().apply { complete() }
+        }
+
+    private suspend fun <U> CdrClientApiClient.Result<U>.handle(
+        onIOError: ErrorHandler = reportIoErrorHandler,
+        onValidationError: ErrorHandler = reportValidationErrorHandler,
+        onSuccess: SuccessHandler<U>,
+    ) {
+        when (this) {
+            is CdrClientApiClient.Result.Success -> onSuccess(response)
+            is CdrClientApiClient.Result.IOError -> onIOError(errors)
+            is CdrClientApiClient.Result.ValidationError -> onValidationError(errors)
         }
     }
 
-    suspend fun updateClientServiceStatus() {
-        cdrClientApiClient.getClientServiceStatus().let { status ->
-            _uiState.value = _uiState.value.copy(clientServiceStatus = status)
-        }
-    }
-
-    fun errorMessageShown() {
+    private val reportIoErrorHandler: ErrorHandler = { errorMap ->
         _uiState.update {
-            it.copy(errorKey = null)
+            it.copy(
+                errorMessageKey = StringResourceWithArgs(
+                    resourceId = Res.string.error_client_communication,
+                    *(errorMap.values.toTypedArray())
+                )
+            )
+        }
+    }
+
+    private val reportValidationErrorHandler: ErrorHandler = { errorMap ->
+        _uiState.update {
+            it.copy(
+                errorMessageKey = StringResourceWithArgs(
+                    resourceId = Res.string.error_client_validation,
+                    errorMap.entries.joinToString("\n"),
+                )
+            )
         }
     }
 
@@ -70,6 +188,7 @@ internal class CdrConfigViewModel(
 
         @JvmStatic
         val STATUS_CHECK_DELAY = 1.seconds
+
     }
 
 }

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/ComposeUtils.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/ComposeUtils.kt
@@ -1,0 +1,62 @@
+package com.swisscom.health.des.cdr.client.ui
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+internal class StringResourceWithArgs(
+    val resourceId: StringResource,
+    vararg val args: Any,
+) {
+    @Composable
+    fun asString(): String {
+        return stringResource(
+            resource = resourceId,
+            formatArgs = (args)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ButtonWithToolTip(
+    label: String,
+    toolTip: String = "",
+    onClick: () -> Unit,
+) =
+    if (toolTip.isNotBlank()) {
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+            tooltip = {
+                PlainTooltip(
+                    caretSize = DpSize(16.dp, 8.dp),
+                    shadowElevation = 16.dp,
+                    shape = MaterialTheme.shapes.extraSmall,
+
+                    ) { Text(toolTip) }
+            },
+            state = rememberTooltipState(
+                isPersistent = true, // set as `false` to make the tooltip automatically disappear after a short time
+            ),
+        ) {
+            Button(
+                onClick = onClick,
+            ) { Text(text = "Apply") }
+        }
+    } else {
+        Button(
+            onClick = onClick,
+        ) {
+            Text(text = label)
+        }
+    }

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/data/CdrClientApiClient.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/data/CdrClientApiClient.kt
@@ -3,65 +3,87 @@ package com.swisscom.health.des.cdr.client.ui.data
 import com.swisscom.health.des.cdr.client.common.DTOs
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import java.net.URL
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 private val logger = KotlinLogging.logger {}
 
 internal class CdrClientApiClient {
 
-    suspend fun shutdownClientServiceProcess(): ShutdownResult = withContext(Dispatchers.IO) {
-        logger.info { "BEGIN - Send command to shut down the client service" }
-        runCatching {
-            HttpClient
-                .configure()
-                .newCall(
-                    HttpClient.get(SHUTDOWN_URL)
-                )
-                .execute()
-                .use { response: Response ->
-                    val responseString: String = response.body
-                        .use { body ->
-                            body?.string() ?: ""
-                        }.also {
-                            logger.trace { "Response body: '$it'" }
-                        }
-
-                    if (response.isSuccessful) {
-                        val shutdownResponse = JSON.decodeFromString<DTOs.ShutdownResponse>(responseString)
-                        logger.info { "END success - Send command to shut down the client service - scheduled for '${shutdownResponse.shutdownScheduledFor}'" }
-                        ShutdownResult.Success()
-                    } else {
-                        logger.error {
-                            "END failed - Send command to shut down the client service; code: " +
-                                    "'${response.code}'; body: '$responseString'"
-                        }
-                        ShutdownResult.Failure()
-                    }
-                }
-        }.fold(
-            onSuccess = { it },
-            onFailure = { error ->
-                logger.error { "END failed - Send command to shut down the client service; error: '$error'" }
-                ShutdownResult.Failure()
-            }
-        )
+    sealed interface Result<U> {
+        data class Success<T>(val response: T) : Result<T>
+        data class IOError<Nothing>(val errors: Map<String, Any>) : Result<Nothing>
+        data class ValidationError<Nothing>(val errors: Map<String, Any>) : Result<Nothing>
     }
 
-    suspend fun getClientServiceStatus(): DTOs.StatusResponse.StatusCode = withContext(Dispatchers.IO) {
+    suspend fun getClientServiceConfiguration(): Result<DTOs.CdrClientConfig> =
+        getAnything<DTOs.CdrClientConfig>(CDR_CLIENT_CONFIG_URL, "Get client service configuration")
+
+    suspend fun updateClientServiceConfiguration(config: DTOs.CdrClientConfig): Result<DTOs.CdrClientConfig> =
+        putAnything<DTOs.CdrClientConfig>(CDR_CLIENT_CONFIG_URL, config, "Update client service configuration")
+
+    suspend fun shutdownClientServiceProcess(): Result<DTOs.ShutdownResponse> =
+        getAnything<DTOs.ShutdownResponse>(SHUTDOWN_URL, "Send command to shut down the client service")
+
+    // TODO: Make condition for retry configurable, so that it can be used for any response type;
+    //  then add retry to getAnything() and use it here as well.
+    suspend fun getClientServiceStatus(retryStrategy: RetryStrategy): DTOs.StatusResponse.StatusCode = withContext(Dispatchers.IO) {
         // logging on DEBUG level as this method gets called every second
-        logger.debug { "BEGIN - Get client service status" }
+        retryStrategy.apply { retryCount ->
+            logger.debug { "BEGIN - Get client service status; retry count '$retryCount'" }
+            runCatching {
+                HttpClient
+                    .configure()
+                    .newCall(
+                        HttpClient.get(STATUS_URL)
+                    )
+                    .execute()
+                    .use { response: Response ->
+                        val responseString: String = response.body
+                            .use { body ->
+                                body?.string() ?: ""
+                            }.also {
+                                logger.trace { "Response body: '$it'" }
+                            }
+
+                        if (response.isSuccessful) {
+                            val statusResponse = JSON.decodeFromString<DTOs.StatusResponse>(responseString)
+                            logger.debug { "END success - Get client service status; retry count '$retryCount'" }
+                            statusResponse.statusCode
+                        } else {
+                            logger.debug {
+                                "END failed - Get client service status; retry count '$retryCount'; code: '${response.code}'; body: '$responseString'"
+                            }
+                            DTOs.StatusResponse.StatusCode.ERROR
+                        }
+                    }
+            }.getOrElse { error ->
+                logger.debug { "END failed - Get client service status; retry count '$retryCount'; error: '$error'" }
+                DTOs.StatusResponse.StatusCode.OFFLINE
+            }
+        }
+    }
+
+    private suspend inline fun <reified T> getAnything(url: URL, action: String): Result<T> = withContext(Dispatchers.IO) {
+        logger.info { "BEGIN - $action" }
         runCatching {
             HttpClient
                 .configure()
                 .newCall(
-                    HttpClient.get(STATUS_URL)
+                    HttpClient.get(url)
                 )
                 .execute()
                 .use { response: Response ->
@@ -73,21 +95,109 @@ internal class CdrClientApiClient {
                         }
 
                     if (response.isSuccessful) {
-                        val statusResponse = JSON.decodeFromString<DTOs.StatusResponse>(responseString)
-                        logger.debug { "END success - Get client service status" }
-                        statusResponse.statusCode
+                        val result = JSON.decodeFromString<T>(responseString)
+                        logger.info { "END success - $action" }
+                        Result.Success(result)
                     } else {
-                        logger.debug {
-                            "END failed - Get client service status; code: '${response.code}'; body: '$responseString'"
+                        logger.info {
+                            "END failed - $action; code: '${response.code}'; body: '$responseString'"
                         }
-                        DTOs.StatusResponse.StatusCode.ERROR
+                        Result.ValidationError(mapOf("statusCode" to response.code, "body" to responseString))
                     }
                 }
         }.getOrElse { error ->
-            logger.debug { "END failed - Get client service status; error: '$error'" }
-            DTOs.StatusResponse.StatusCode.OFFLINE
+            logger.info { "END failed - $action; error: '$error'" }
+            Result.IOError(mapOf("exception" to error))
         }
     }
+
+    private suspend inline fun <reified T> putAnything(url: URL, body: T, action: String): Result<T> = withContext(Dispatchers.IO) {
+        logger.info { "BEGIN - $action" }
+        runCatching {
+            HttpClient
+                .configure()
+                .newCall(
+                    HttpClient.put(url, JSON.encodeToString(body))
+                )
+                .execute()
+                .use { response: Response ->
+                    val responseString: String = response.body
+                        .use { body ->
+                            body?.string() ?: ""
+                        }.also {
+                            logger.trace { "Response body: '$it'" }
+                        }
+
+                    if (response.isSuccessful) {
+                        val result = JSON.decodeFromString<T>(responseString)
+                        logger.info { "END success - $action" }
+                        Result.Success(result)
+                    } else {
+                        logger.info {
+                            "END failed - $action; code: '${response.code}'; body: '$responseString'"
+                        }
+                        runCatching {
+                            JSON.parseToJsonElement(responseString).jsonObject
+                        }.mapCatching { problemJson ->
+                            problemJson.entries.filter { (key, _) -> key != "status" && key != "message" && key != "title" && key != "type" }
+                        }.mapCatching { problemProperties ->
+                            problemProperties.associate { it.key to it.value.jsonPrimitive.content }
+                        }.mapCatching<Result<T>, Map<String, String>> { problemPropertiesMap ->
+                            Result.ValidationError(problemPropertiesMap)
+                        }.getOrElse { exception ->
+                            logger.debug {
+                                "failed to parse response body as problem json with a properties map; response: '$responseString', exception: $exception"
+                            }
+                            Result.ValidationError(mapOf("statusCode" to response.code, "body" to responseString))
+                        }
+                    }
+                }
+        }.getOrElse { error ->
+            logger.info { "END failed - $action; error: '$error'" }
+            Result.IOError(mapOf("exception" to error))
+        }
+    }
+
+    enum class RetryStrategy {
+        NONE,
+        LINEAR,
+        EXPONENTIAL;
+
+        suspend inline fun apply(block: suspend (retryCount: Int) -> DTOs.StatusResponse.StatusCode): DTOs.StatusResponse.StatusCode =
+            when (this) {
+                NONE -> block(0)
+                LINEAR -> retry(initialDelay = 1.seconds, factor = 1.0, times = 25, block = block)
+                EXPONENTIAL -> retry(initialDelay = 100.milliseconds, factor = 2.0, times = 8, block = block)
+            }
+
+        private suspend inline fun retry(
+            times: Int,
+            initialDelay: Duration,
+            maxDelay: Duration = 10.seconds,
+            factor: Double,
+            block: suspend (Int) -> DTOs.StatusResponse.StatusCode
+        ): DTOs.StatusResponse.StatusCode {
+            var currentDelay: Duration = initialDelay
+            repeat(times - 1) { retryCount ->
+                val result = block(retryCount)
+                if (result != FAILED_STATUS_CODE) {
+                    return result
+                } else {
+                    logger.debug { "CDR client service is '${FAILED_STATUS_CODE}', retrying after '$currentDelay'" }
+                }
+                delay(currentDelay)
+                currentDelay = (currentDelay * factor).coerceAtMost(maxDelay)
+            }
+            return block(times - 1) // last attempt
+        }
+
+        companion object {
+            @JvmStatic
+            private val FAILED_STATUS_CODE = DTOs.StatusResponse.StatusCode.OFFLINE
+        }
+
+    }
+
 
     companion object {
         private const val CDR_CLIENT_BASE_URL = "http://localhost:8191/api"
@@ -99,15 +209,14 @@ internal class CdrClientApiClient {
         private val STATUS_URL = "$CDR_CLIENT_BASE_URL/status".toHttpUrl().toUrl()
 
         @JvmStatic
+        private val CDR_CLIENT_CONFIG_URL = "$CDR_CLIENT_BASE_URL/service-configuration".toHttpUrl().toUrl()
+
+        @JvmStatic
         private val JSON = Json {}
     }
 
 }
 
-internal sealed class ShutdownResult {
-    class Success : ShutdownResult()
-    class Failure : ShutdownResult()
-}
 
 private object HttpClient : OkHttpClient() {
 
@@ -120,6 +229,14 @@ private object HttpClient : OkHttpClient() {
         return Request.Builder()
             .url(to)
             .get()
+            .build()
+    }
+
+    fun put(to: URL, body: String): Request {
+        return Request.Builder()
+            .url(to)
+            .put(body.toRequestBody())
+            .header("Content-Type", "application/json")
             .build()
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,8 +49,8 @@ spring-boot-starter-actuator = { group = "org.springframework.boot", name = "spr
 spring-boot-starter-webflux = { group = "org.springframework.boot", name = "spring-boot-starter-webflux" }
 spring-retry = { group = "org.springframework.retry", name = "spring-retry" }
 spring-cloud-dependencies = { group = "org.springframework.cloud", name = "spring-cloud-dependencies", version.ref = "spring-cloud" }
-spring-cloud-context = { group = "org.springframework.cloud", name = "spring-cloud-context" }
 jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml" }
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin" }
 conveyor-control = { group = "dev.hydraulic.conveyor", name = "conveyor-control", version.ref = "conveyor-control-api" }
 jna = { group = "net.java.dev.jna", name = "jna-platform", version.ref = "jna" }
 uitiles = { group = "com.github.alorma.compose-settings", name = "ui-tiles", version.ref = "ui-tiles" }


### PR DESCRIPTION
…ed with the UI and persisted through the cdr service.

To update the single property I implemented a generic way to update any property that is flagged as updatable (by a marker interface) and applied the new mechanism to the existing client credential auto-renewal option. The test coverage has suffered. Will need to be brought up again...