### PR TITLE
#42988 we now always rely on the state transitions as reported by the…

### DIFF
--- a/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/DTOs.kt
+++ b/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/DTOs.kt
@@ -130,7 +130,7 @@ class DTOs {
         val errorCodes: List<String> = emptyList(),
     ) {
 
-        enum class StatusCode(val isOnlineState: Boolean) {
+        enum class StatusCode(val isOnlineCategory: Boolean) {
             UNKNOWN(false),
             SYNCHRONIZING(true),
             DISABLED(true),
@@ -138,8 +138,8 @@ class DTOs {
             BROKEN(true),
             OFFLINE(false);
 
-            val isOfflineState: Boolean
-                get() = !isOnlineState
+            val isOfflineCategory: Boolean
+                get() = !isOnlineCategory
         }
 
     }

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/CdrConfigScreen.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/CdrConfigScreen.kt
@@ -77,7 +77,7 @@ internal fun CdrConfigScreen(
 
     LaunchedEffect(uiState.clientServiceConfig, uiState.clientServiceStatus) {
         initialConfigLoaded = uiState.clientServiceConfig !== DTOs.CdrClientConfig.EMPTY
-        canEdit = initialConfigLoaded && uiState.clientServiceStatus.isOnlineState
+        canEdit = initialConfigLoaded && uiState.clientServiceStatus.isOnlineCategory
     }
 
     Scaffold(


### PR DESCRIPTION
… service (or the lack of such a report) to decide when to load the configuration to avoid reporting unnecessary communication errors on UI launch