### PR TITLE
Ignore subfolders in the tmp directory for downloaded files.

### DIFF
--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/CdrClientApplication.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/CdrClientApplication.kt
@@ -11,6 +11,7 @@ import java.nio.file.LinkOption
 import java.nio.file.Path
 import kotlin.io.path.appendText
 import kotlin.io.path.createFile
+import kotlin.io.path.createParentDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
@@ -112,16 +113,21 @@ private val tmpLogFile: Path? by lazy {
 
     fileOrDirStr
         ?.let { pathStr: String ->
-            val fileOrDir = Path.of(pathStr)
-            if (fileOrDir.isDirectory()) {
-                fileOrDir.resolve("cdr-service-init.log")
-            } else {
-                fileOrDir.resolveSibling("cdr-service-init.log")
-            }.also { file: Path ->
-                if (!file.exists(
-                        LinkOption.NOFOLLOW_LINKS
-                    )
-                ) file.createFile()
+            runCatching {
+                val fileOrDir = Path.of(pathStr)
+                if (fileOrDir.isDirectory()) {
+                    fileOrDir.resolve("cdr-service-init.log")
+                } else {
+                    fileOrDir.resolveSibling("cdr-service-init.log")
+                }.also { file: Path ->
+                    if (!file.exists(LinkOption.NOFOLLOW_LINKS)) {
+                        file.createParentDirectories()
+                        file.createFile()
+                    }
+                }
+            }.getOrElse { t ->
+                System.err.println("WARNING: could not create init log file, falling back to stdout: ${t.message}")
+                null
             }
         }
 }

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/FileMonitoringService.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/FileMonitoringService.kt
@@ -94,7 +94,7 @@ internal class FileMonitoringService(
             val count = if (tempFolder.exists() && tempFolder.isDirectory()) {
                 val threshold = Instant.now().minus(config.oldFileThreshold)
 
-                Files.walk(tempFolder)
+                Files.list(tempFolder)
                     .asSequence()
                     .filter { it.isRegularFile() && it.extension.lowercase() == TEMP_FILE_EXTENSION }
                     .count { file ->

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/FileMonitoringServiceTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/FileMonitoringServiceTest.kt
@@ -162,20 +162,6 @@ internal class FileMonitoringServiceTest {
     }
 
     @Test
-    fun `should count files in nested temp directories`() = runTest {
-        val threeHoursAgo = Instant.now().minus(3, ChronoUnit.HOURS)
-        val nestedDir = tempDir.resolve("subfolder").createDirectories()
-
-        createTempFile(tempDir, "old1.$TEMP_FILE_EXTENSION", threeHoursAgo)
-        createTempFile(nestedDir, "old2.$TEMP_FILE_EXTENSION", threeHoursAgo)
-
-        fileMonitoringService.checkFileStatus()
-
-        val status = fileMonitoringService.monitoringStatus.value
-        assertEquals(2, status.oldTempFileCount)
-    }
-
-    @Test
     fun `should handle both error files and old temp files`() = runTest {
         val threeHoursAgo = Instant.now().minus(3, ChronoUnit.HOURS)
 

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/FileMonitoringWarningBanner.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/FileMonitoringWarningBanner.kt
@@ -2,6 +2,10 @@ package com.swisscom.health.des.cdr.client.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,34 +22,34 @@ internal fun FileMonitoringWarningBanner(
     modifier: Modifier = Modifier,
     fileMonitoringStatus: DTOs.FileMonitoringStatusResponse
 ) {
-    androidx.compose.material3.Card(
+    Card(
         modifier = modifier,
-        colors = androidx.compose.material3.CardDefaults.cardColors(
+        colors = CardDefaults.cardColors(
             containerColor = Color(0xFFFFF3CD),
         ),
     ) {
         Column(
             modifier = Modifier.padding(12.dp)
         ) {
-            androidx.compose.material3.Text(
+            Text(
                 text = "⚠️ ${stringResource(Res.string.label_file_monitoring_warnings)}",
-                style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleMedium,
                 color = Color(0xFF856404)
             )
 
             if (fileMonitoringStatus.errorFileCount > 0) {
-                androidx.compose.material3.Text(
+                Text(
                     text = "• ${stringResource(Res.string.label_file_monitoring_error_files, fileMonitoringStatus.errorFileCount)}",
-                    style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodyMedium,
                     color = Color(0xFF856404),
                     modifier = Modifier.padding(top = 4.dp)
                 )
             }
 
             if (fileMonitoringStatus.oldTempFileCount > 0) {
-                androidx.compose.material3.Text(
+                Text(
                     text = "• ${stringResource(Res.string.label_file_monitoring_old_temp_files, fileMonitoringStatus.oldTempFileCount)}",
-                    style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodyMedium,
                     color = Color(0xFF856404),
                     modifier = Modifier.padding(top = 4.dp)
                 )

--- a/conveyor_w2019-dev.conf
+++ b/conveyor_w2019-dev.conf
@@ -87,7 +87,7 @@ app {
     
     manifests {
       msix {
-        capabilities = ["rescap:runFullTrust", "rescap:localSystemServices"]
+        capabilities = ["rescap:runFullTrust"]
         // https://conveyor.hydraulic.dev/18.1/configs/windows/#virtualization
         virtualization {
           # Exclude the entire RoamingAppData directory from virtualization.

--- a/conveyor_w2019-dev.conf
+++ b/conveyor_w2019-dev.conf
@@ -87,11 +87,7 @@ app {
     
     manifests {
       msix {
-        namespaces = {
-          uap10: "http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
-        }
-        ignorable-namespaces += "uap10"
-        capabilities = ["rescap:runFullTrust", "rescap:localSystemServices", "rescap:packagedServices"]
+        capabilities = ["rescap:runFullTrust", "rescap:localSystemServices"]
         // https://conveyor.hydraulic.dev/18.1/configs/windows/#virtualization
         virtualization {
           # Exclude the entire RoamingAppData directory from virtualization.

--- a/conveyor_w2019.conf
+++ b/conveyor_w2019.conf
@@ -87,7 +87,7 @@ app {
     }
     manifests {
       msix {
-        capabilities = ["rescap:runFullTrust", "rescap:localSystemServices"]
+        capabilities = ["rescap:runFullTrust"]
         // https://conveyor.hydraulic.dev/18.1/configs/windows/#virtualization
         virtualization {
           # Exclude the entire RoamingAppData directory from virtualization.

--- a/conveyor_w2019.conf
+++ b/conveyor_w2019.conf
@@ -87,11 +87,7 @@ app {
     }
     manifests {
       msix {
-        namespaces = {
-          uap10: "http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
-        }
-        ignorable-namespaces += "uap10"
-        capabilities = ["rescap:runFullTrust", "rescap:localSystemServices", "rescap:packagedServices"]
+        capabilities = ["rescap:runFullTrust", "rescap:localSystemServices"]
         // https://conveyor.hydraulic.dev/18.1/configs/windows/#virtualization
         virtualization {
           # Exclude the entire RoamingAppData directory from virtualization.


### PR DESCRIPTION
If the tmpLogDir can't be created log to the console. Remove features not available for Windows Server 2019 from the conveyor conf file.