### PR TITLE
#47096 Made IdP tenant id and OAuth scope enums as well; cdr-api host…

### DIFF
--- a/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/DTOs.kt
+++ b/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/DTOs.kt
@@ -114,6 +114,7 @@ class DTOs {
         NOT_A_DIRECTORY,
         DIRECTORY_NOT_FOUND,
         ILLEGAL_VALUE,
+        ILLEGAL_VALUE_COMBINATION,
         NOT_READ_WRITABLE,
         LOCAL_DIR_OVERLAPS_WITH_SOURCE_DIRS,
         LOCAL_DIR_OVERLAPS_WITH_TARGET_DIRS,
@@ -297,10 +298,10 @@ class DTOs {
 
         @Serializable
         data class IdpCredentials(
-            val tenantId: String,
+            val tenantId: DomainObjects.TenantId,
             val clientId: String,
             val clientSecret: String,
-            val scope: String,
+            val scope: DomainObjects.OAuthScope,
             val renewCredential: Boolean,
             val maxCredentialAge: Duration,
             val lastCredentialRenewalTime: Instant,
@@ -308,10 +309,10 @@ class DTOs {
             companion object {
                 @JvmStatic
                 val EMPTY = IdpCredentials(
-                    tenantId = EMPTY_STRING,
+                    tenantId = DomainObjects.TenantId.PRODUCTION,
                     clientId = EMPTY_STRING,
                     clientSecret = EMPTY_STRING,
-                    scope = EMPTY_STRING,
+                    scope = DomainObjects.OAuthScope.PRODUCTION,
                     renewCredential = false,
                     maxCredentialAge = Duration.ZERO,
                     lastCredentialRenewalTime = Instant.EPOCH

--- a/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/DomainObjects.kt
+++ b/cdr-client-common/src/main/kotlin/com/swisscom/health/des/cdr/client/common/DomainObjects.kt
@@ -18,7 +18,6 @@ class DomainObjects {
         ARCHIVE_DIRECTORY,
         IDP_CLIENT_PASSWORD,
         IDP_CLIENT_ID,
-        IDP_TENANT_ID,
         IDP_CLIENT_SECRET_RENWAL_TIME,
         IDP_CLIENT_SECRET_RENWAL,
         FILE_BUSY_TEST_TIMEOUT,
@@ -39,10 +38,10 @@ class DomainObjects {
 
     enum class ApiEndpoint(val protocol: String, val port: Int, val host: String) {
         PRODUCTION("https", WELL_KNOWN_HTTPS_PORT, "cdr.health.swisscom.ch"),
-        PROD_INTERNAL("https", WELL_KNOWN_HTTPS_PORT, "cdr-prod-fn.azurewebsites.net"),
+        PRODUCTION_INTERNAL("https", WELL_KNOWN_HTTPS_PORT, "cdr-prod-fn.azurewebsites.net"),
         STAGING("https", WELL_KNOWN_HTTPS_PORT, "stg.cdr.health.swisscom.ch"),
         STAGING_INTERNAL("https", WELL_KNOWN_HTTPS_PORT, "cdr-stg-fn.azurewebsites.net"),
-        INT_INTERNAL("https", WELL_KNOWN_HTTPS_PORT, "cdr-int-fn.azurewebsites.net"),
+        INTEGRATION_INTERNAL("https", WELL_KNOWN_HTTPS_PORT, "cdr-int-fn.azurewebsites.net"),
         // apparently, on MS Windows, it is possible for non-admin users to run processes that listen on port 80;
         // as non-admin users may call the cdr-client-service API and set the CDR API endpoint to `LOCALHOST` we
         // cannot allow a local endpoint that the same non-admin user may be able to control
@@ -55,9 +54,33 @@ class DomainObjects {
                 entries.firstOrNull {
                     it.protocol == protocol && it.host == host && it.port == port
                 } ?: UNKNOWN
-
         }
+    }
 
+    enum class TenantId(val tenantId: String) {
+        PRODUCTION("70b434db-eccb-4280-95dc-1e59220aca55"),
+        STAGING("dc5f3d15-71a0-47ad-a792-f708c9b4d123"),
+        INTEGRATION("f5a99f8d-dca6-413c-ba36-9e23b4720930"),
+        LOCALHOST("test-tenant-client-id"),
+        UNKNOWN("");
+
+        companion object {
+            fun fromTenantId(tenantId: String): TenantId =
+                entries.firstOrNull { it.tenantId == tenantId } ?: UNKNOWN
+        }
+    }
+
+    enum class OAuthScope(val scope: String) {
+        PRODUCTION("https://identity.health.swisscom.ch/CdrApi/.default"),
+        STAGING("https://tst.identity.health.swisscom.ch/CdrApi/.default"),
+        INTEGRATION("https://dev.identity.health.swisscom.ch/CdrApi/.default"),
+        LOCALHOST("https://localhost/CdrApi/.default"),
+        UNKNOWN("");
+
+        companion object {
+            fun fromScope(scope: String): OAuthScope =
+                entries.firstOrNull { it.scope == scope } ?: UNKNOWN
+        }
     }
 
     private companion object {

--- a/cdr-client-service/conf/default-application-customer.yaml
+++ b/cdr-client-service/conf/default-application-customer.yaml
@@ -7,7 +7,7 @@ client:
     username:
     password:
   idp-credentials:
-    tenant-id: value-required
+    tenant-id: 70b434db-eccb-4280-95dc-1e59220aca55
     client-id: value-required
     client-secret: value-required
     scope: https://identity.health.swisscom.ch/CdrApi/.default

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/config/ConfigConverter.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/config/ConfigConverter.kt
@@ -78,10 +78,10 @@ internal fun Endpoint.toDto(): DomainObjects.ApiEndpoint =
 
 internal fun IdpCredentials.toDto(): DTOs.CdrClientConfig.IdpCredentials =
     DTOs.CdrClientConfig.IdpCredentials(
-        tenantId = tenantId.id,
+        tenantId = DomainObjects.TenantId.fromTenantId(tenantId.id),
         clientId = clientId.id,
         clientSecret = if (clientSecret == ClientSecret.NO_SECRET) clientSecret.value else ClientSecret.MASKED_SECRET.value,
-        scope = scope.scope,
+        scope = DomainObjects.OAuthScope.fromScope(scope.scope),
         renewCredential = renewCredential.value,
         maxCredentialAge = maxCredentialAge,
         lastCredentialRenewalTime = lastCredentialRenewalTime.instant,
@@ -190,10 +190,10 @@ internal inline fun <reified T : Endpoint> DomainObjects.ApiEndpoint.toCdrClient
 
 internal fun DTOs.CdrClientConfig.IdpCredentials.toCdrClientConfig(): IdpCredentials =
     IdpCredentials(
-        tenantId = TenantId(tenantId),
+        tenantId = TenantId(tenantId.tenantId),
         clientId = ClientId(clientId),
         clientSecret = ClientSecret(clientSecret),
-        scope = Scope(scope),
+        scope = Scope(scope.scope),
         renewCredential = RenewCredential(renewCredential),
         maxCredentialAge = maxCredentialAge,
         lastCredentialRenewalTime = LastCredentialRenewalTime(lastCredentialRenewalTime),

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigValidationService.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigValidationService.kt
@@ -116,34 +116,41 @@ internal class ConfigValidationService(
             failure(ILLEGAL_VALUE_COMBINATION)
         }
 
-        return if (cdrApiEndpoint == DomainObjects.ApiEndpoint.UNKNOWN) {
-            illegalValueFailure
-        } else if (cdrApiEndpoint == DomainObjects.ApiEndpoint.PRODUCTION || cdrApiEndpoint == DomainObjects.ApiEndpoint.PRODUCTION_INTERNAL) {
-            if (idpCredentials.tenantId != DomainObjects.TenantId.PRODUCTION || idpCredentials.scope != DomainObjects.OAuthScope.PRODUCTION) {
-                illegalValueCombinationFailure
-            } else {
-                ValidationResult.Success
+
+        return when (cdrApiEndpoint) {
+            DomainObjects.ApiEndpoint.PRODUCTION, DomainObjects.ApiEndpoint.PRODUCTION_INTERNAL -> {
+                if (idpCredentials.tenantId != DomainObjects.TenantId.PRODUCTION || idpCredentials.scope != DomainObjects.OAuthScope.PRODUCTION) {
+                    illegalValueCombinationFailure
+                } else {
+                    ValidationResult.Success
+                }
             }
-        } else if (cdrApiEndpoint == DomainObjects.ApiEndpoint.STAGING || cdrApiEndpoint == DomainObjects.ApiEndpoint.STAGING_INTERNAL) {
-            if (idpCredentials.tenantId != DomainObjects.TenantId.STAGING || idpCredentials.scope != DomainObjects.OAuthScope.STAGING) {
-                illegalValueCombinationFailure
-            } else {
-                ValidationResult.Success
+
+            DomainObjects.ApiEndpoint.STAGING, DomainObjects.ApiEndpoint.STAGING_INTERNAL -> {
+                if (idpCredentials.tenantId != DomainObjects.TenantId.STAGING || idpCredentials.scope != DomainObjects.OAuthScope.STAGING) {
+                    illegalValueCombinationFailure
+                } else {
+                    ValidationResult.Success
+                }
             }
-        } else if (cdrApiEndpoint == DomainObjects.ApiEndpoint.INTEGRATION_INTERNAL) {
-            if (idpCredentials.tenantId != DomainObjects.TenantId.INTEGRATION || idpCredentials.scope != DomainObjects.OAuthScope.INTEGRATION) {
-                illegalValueCombinationFailure
-            } else {
-                ValidationResult.Success
+
+            DomainObjects.ApiEndpoint.INTEGRATION_INTERNAL -> {
+                if (idpCredentials.tenantId != DomainObjects.TenantId.INTEGRATION || idpCredentials.scope != DomainObjects.OAuthScope.INTEGRATION) {
+                    illegalValueCombinationFailure
+                } else {
+                    ValidationResult.Success
+                }
             }
-        } else if (cdrApiEndpoint == DomainObjects.ApiEndpoint.LOCALHOST) {
-            if (idpCredentials.tenantId != DomainObjects.TenantId.LOCALHOST || idpCredentials.scope != DomainObjects.OAuthScope.LOCALHOST) {
-                illegalValueCombinationFailure
-            } else {
-                ValidationResult.Success
+
+            DomainObjects.ApiEndpoint.LOCALHOST -> {
+                if (idpCredentials.tenantId != DomainObjects.TenantId.LOCALHOST || idpCredentials.scope != DomainObjects.OAuthScope.LOCALHOST) {
+                    illegalValueCombinationFailure
+                } else {
+                    ValidationResult.Success
+                }
             }
-        } else {
-            ValidationResult.Success
+
+            DomainObjects.ApiEndpoint.UNKNOWN -> illegalValueFailure
         }
     }
 

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigValidationService.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigValidationService.kt
@@ -12,6 +12,7 @@ import com.swisscom.health.des.cdr.client.common.DTOs.ValidationMessageKey.ERROR
 import com.swisscom.health.des.cdr.client.common.DTOs.ValidationMessageKey.FILE_BUSY_TEST_TIMEOUT_TOO_LONG
 import com.swisscom.health.des.cdr.client.common.DTOs.ValidationMessageKey.ILLEGAL_MODE
 import com.swisscom.health.des.cdr.client.common.DTOs.ValidationMessageKey.ILLEGAL_VALUE
+import com.swisscom.health.des.cdr.client.common.DTOs.ValidationMessageKey.ILLEGAL_VALUE_COMBINATION
 import com.swisscom.health.des.cdr.client.common.DTOs.ValidationMessageKey.LOCAL_DIR_OVERLAPS_WITH_SOURCE_DIRS
 import com.swisscom.health.des.cdr.client.common.DTOs.ValidationMessageKey.LOCAL_DIR_OVERLAPS_WITH_TARGET_DIRS
 import com.swisscom.health.des.cdr.client.common.DTOs.ValidationMessageKey.NOT_A_DIRECTORY
@@ -47,7 +48,7 @@ private val logger = KotlinLogging.logger {}
 @Service
 @Suppress("TooManyFunctions", "LargeClass")
 internal class ConfigValidationService(
-    private val config: CdrClientConfig
+    private val config: CdrClientConfig,
 ) {
 
     val isConfigValid: Boolean by lazy { validateAllConfigurationItems(config.toDto()) is ValidationResult.Success }
@@ -55,7 +56,7 @@ internal class ConfigValidationService(
     fun validateAllConfigurationItems(config: DTOs.CdrClientConfig): ValidationResult {
         val validations = mutableListOf<ValidationResult>()
 
-        validations.add(validateCdrApiEndpoint(config.cdrApi))
+        validations.add(validateCdrApiEndpoint(config.cdrApi, config.idpCredentials))
         validations.add(validateDirectoriesAreAbsolute(config))
         validations.add(validateDirectoryIsReadWritable(config.localFolder))
         validations.add(validateDirectoryOverlap(config))
@@ -96,16 +97,51 @@ internal class ConfigValidationService(
         TODO()
     }
 
-    fun validateCdrApiEndpoint(cdrApiEndpoint: DomainObjects.ApiEndpoint): ValidationResult {
-        return if (cdrApiEndpoint == DomainObjects.ApiEndpoint.UNKNOWN) {
-            ValidationResult.Failure(
-                listOf(
-                    ValidationDetail.ConfigItemDetail(
-                        configItem = DomainObjects.ConfigurationItem.CDR_API_HOST,
-                        messageKey = ILLEGAL_VALUE
-                    )
+    @Suppress("CyclomaticComplexMethod")
+    fun validateCdrApiEndpoint(cdrApiEndpoint: DomainObjects.ApiEndpoint, idpCredentials: DTOs.CdrClientConfig.IdpCredentials): ValidationResult {
+        fun failure(messageKey: DTOs.ValidationMessageKey) = ValidationResult.Failure(
+            listOf(
+                ValidationDetail.ConfigItemDetail(
+                    configItem = DomainObjects.ConfigurationItem.CDR_API_HOST,
+                    messageKey = messageKey
                 )
             )
+        )
+
+        val illegalValueFailure: ValidationResult.Failure by lazy(LazyThreadSafetyMode.NONE) {
+            failure(ILLEGAL_VALUE)
+        }
+
+        val illegalValueCombinationFailure: ValidationResult.Failure by lazy(LazyThreadSafetyMode.NONE) {
+            failure(ILLEGAL_VALUE_COMBINATION)
+        }
+
+        return if (cdrApiEndpoint == DomainObjects.ApiEndpoint.UNKNOWN) {
+            illegalValueFailure
+        } else if (cdrApiEndpoint == DomainObjects.ApiEndpoint.PRODUCTION || cdrApiEndpoint == DomainObjects.ApiEndpoint.PRODUCTION_INTERNAL) {
+            if (idpCredentials.tenantId != DomainObjects.TenantId.PRODUCTION || idpCredentials.scope != DomainObjects.OAuthScope.PRODUCTION) {
+                illegalValueCombinationFailure
+            } else {
+                ValidationResult.Success
+            }
+        } else if (cdrApiEndpoint == DomainObjects.ApiEndpoint.STAGING || cdrApiEndpoint == DomainObjects.ApiEndpoint.STAGING_INTERNAL) {
+            if (idpCredentials.tenantId != DomainObjects.TenantId.STAGING || idpCredentials.scope != DomainObjects.OAuthScope.STAGING) {
+                illegalValueCombinationFailure
+            } else {
+                ValidationResult.Success
+            }
+        } else if (cdrApiEndpoint == DomainObjects.ApiEndpoint.INTEGRATION_INTERNAL) {
+            if (idpCredentials.tenantId != DomainObjects.TenantId.INTEGRATION || idpCredentials.scope != DomainObjects.OAuthScope.INTEGRATION) {
+                illegalValueCombinationFailure
+            } else {
+                ValidationResult.Success
+            }
+        } else if (cdrApiEndpoint == DomainObjects.ApiEndpoint.LOCALHOST) {
+            if (idpCredentials.tenantId != DomainObjects.TenantId.LOCALHOST || idpCredentials.scope != DomainObjects.OAuthScope.LOCALHOST) {
+                illegalValueCombinationFailure
+            } else {
+                ValidationResult.Success
+            }
         } else {
             ValidationResult.Success
         }
@@ -703,10 +739,6 @@ internal class ConfigValidationService(
         validateIsNotBlankOrPlaceholder(
             value = credentials.clientSecret,
             configItem = DomainObjects.ConfigurationItem.IDP_CLIENT_PASSWORD
-        ).let { validations.add(it) }
-        validateIsNotBlankOrPlaceholder(
-            value = credentials.tenantId,
-            configItem = DomainObjects.ConfigurationItem.IDP_TENANT_ID
         ).let { validations.add(it) }
 
         return validations.fold(

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/http/WebOperations.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/http/WebOperations.kt
@@ -188,10 +188,10 @@ internal class WebOperations(
         logger.debug { "validating credentials for tenant id: '${idpCredentials.tenantId}'" }
         retryIOExceptionsAndServerErrors.execute<OAuth2AuthNService.AuthNResponse, Exception> { retry: RetryContext ->
             val idpEndpoint = config.idpEndpoint.toString()
-            val correctedIdpEndpoint = if (config.idpCredentials.tenantId.id == idpCredentials.tenantId)
+            val correctedIdpEndpoint = if (config.idpCredentials.tenantId.id == idpCredentials.tenantId.tenantId)
                 idpEndpoint
             else // only replace the first path segment after the host with the tenant id from the provided credentials
-                idpEndpoint.replace(Regex("(http[s]?://[^/]+/)[^/]+"), "$1${idpCredentials.tenantId}")
+                idpEndpoint.replace(Regex("(http[s]?://[^/]+/)[^/]+"), "$1${idpCredentials.tenantId.tenantId}")
 
             if (retry.retryCount > 0) {
                 logger.debug {

--- a/cdr-client-service/src/main/resources/config/application-dev.yaml
+++ b/cdr-client-service/src/main/resources/config/application-dev.yaml
@@ -6,7 +6,7 @@ client:
   idp-credentials:
     tenant-id: ${CDR_B2C_TENANT_ID:test-tenant-client-id} # `test-tenant-client-id` is the required value if the MockOauth2Server is used; see its `config.json`
     client-id: ${CDR_CLIENT_ID:easy-system-test-user-id}
-    scope: https://dev.identity.health.swisscom.ch/CdrApi/.default
+    scope: https://localhost/CdrApi/.default
     client-secret: ${CDR_CLIENT_SECRET:Placeholder_test-secret}
     renew-credential: true
     last-credential-renewal-time: 2030-01-01T00:00:00Z

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/config/ConfigConverterTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/config/ConfigConverterTest.kt
@@ -1,6 +1,7 @@
 package com.swisscom.health.des.cdr.client.config
 
 import com.swisscom.health.des.cdr.client.common.DTOs
+import com.swisscom.health.des.cdr.client.common.DomainObjects
 import com.swisscom.health.des.cdr.client.xml.DocumentType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -42,10 +43,10 @@ class ConfigConverterTest {
         ),
         filesInProgressCacheSize = DataSize.ofMegabytes(1L),
         idpCredentials = IdpCredentials(
-            tenantId = TenantId("fake-tenant-id"),
+            tenantId = TenantId(DomainObjects.TenantId.LOCALHOST.tenantId),
             clientId = ClientId("fake-client-id"),
             clientSecret = ClientSecret("fake-client-secret"),
-            scope = Scope("scope1"),
+            scope = Scope(DomainObjects.OAuthScope.LOCALHOST.scope),
             renewCredential = RenewCredential.ENABLED,
             maxCredentialAge = Duration.ofDays(30),
             lastCredentialRenewalTime = LastCredentialRenewalTime(LAST_UPDATED_AT),
@@ -104,10 +105,10 @@ class ConfigConverterTest {
         ),
         filesInProgressCacheSize = DataSize.ofMegabytes(1L),
         idpCredentials = IdpCredentials(
-            tenantId = TenantId("fake-tenant-id"),
+            tenantId = TenantId(DomainObjects.TenantId.LOCALHOST.tenantId),
             clientId = ClientId("fake-client-id"),
             clientSecret = ClientSecret("fake-client-secret"),
-            scope = Scope("scope1"),
+            scope = Scope(DomainObjects.OAuthScope.LOCALHOST.scope),
             renewCredential = RenewCredential.ENABLED,
             maxCredentialAge = Duration.ofDays(30),
             lastCredentialRenewalTime = LastCredentialRenewalTime(LAST_UPDATED_AT),

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigValidationServiceTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigValidationServiceTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
 import org.springframework.core.env.Environment
 import org.springframework.http.MediaType
@@ -609,6 +610,16 @@ internal class ConfigValidationServiceTest {
         assertEquals(DTOs.ValidationMessageKey.NOT_A_DIRECTORY, configItemDetail.messageKey)
     }
 
+    @Test
+    fun `test validation error if cdr-api is illegal host`() {
+        fail("todo")
+    }
+
+    @Test
+    fun `test validation error if cdr-api host and-or scope and-or tenant are from different environments`() {
+        fail("todo")
+    }
+
     private fun createCdrClientConfig(customers: List<Connector>, defaultLocalFolder: Path = localFolder0): CdrClientConfig =
         CdrClientConfig(
             fileSynchronizationEnabled = FileSynchronization.ENABLED,
@@ -632,10 +643,10 @@ internal class ConfigValidationServiceTest {
             retryDelay = listOf(Duration.ofSeconds(1)),
             filesInProgressCacheSize = DataSize.ofMegabytes(1),
             idpCredentials = IdpCredentials(
-                tenantId = TenantId("fake-tenant-id"),
+                tenantId = TenantId(DomainObjects.TenantId.LOCALHOST.tenantId),
                 clientId = ClientId("fake-client-id"),
                 clientSecret = ClientSecret("fake-client-secret"),
-                scope = Scope("CDR"),
+                scope = Scope(DomainObjects.OAuthScope.LOCALHOST.scope),
                 renewCredential = RenewCredential(true),
                 lastCredentialRenewalTime = BEGINNING_OF_TIME,
             ),

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigValidationServiceTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/ConfigValidationServiceTest.kt
@@ -4,6 +4,7 @@ package com.swisscom.health.des.cdr.client.handler
 
 import com.swisscom.health.des.cdr.client.common.DTOs
 import com.swisscom.health.des.cdr.client.common.DomainObjects
+import com.swisscom.health.des.cdr.client.common.DomainObjects.ApiEndpoint
 import com.swisscom.health.des.cdr.client.config.CdrApi
 import com.swisscom.health.des.cdr.client.config.CdrClientConfig
 import com.swisscom.health.des.cdr.client.config.ClientId
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
 import org.springframework.core.env.Environment
 import org.springframework.http.MediaType
@@ -560,7 +560,7 @@ internal class ConfigValidationServiceTest {
             val service = ConfigValidationService(config)
             val result = service.validateAllConfigurationItems(config.toDto())
             assertInstanceOf<DTOs.ValidationResult.Failure>(result)
-            val details = result.validationDetails.mapNotNull { it as? DTOs.ValidationDetail.PathDetail }
+            val details = result.validationDetails.filterIsInstance<DTOs.ValidationDetail.PathDetail>()
             val failedPaths = details.map { it.path }
             assertTrue(failedPaths.contains("relative/source"))
             assertTrue(failedPaths.contains("relative/target"))
@@ -612,12 +612,48 @@ internal class ConfigValidationServiceTest {
 
     @Test
     fun `test validation error if cdr-api is illegal host`() {
-        fail("todo")
+        val config = createCdrClientConfig(blueSkyConnectors()).run {
+            copy(
+                cdrApi = cdrApi.copy(
+                    host = Host("illegal host!")
+                )
+            )
+        }
+        val service = ConfigValidationService(config)
+        val result = service.validateAllConfigurationItems(config.toDto())
+
+        assertInstanceOf<DTOs.ValidationResult.Failure>(result)
+        assertEquals(1, result.validationDetails.size)
+
+        val validationDetail = result.validationDetails.first()
+        assertInstanceOf<DTOs.ValidationDetail.ConfigItemDetail>(validationDetail)
+        assertEquals(DomainObjects.ConfigurationItem.CDR_API_HOST, validationDetail.configItem)
+        assertEquals(DTOs.ValidationMessageKey.ILLEGAL_VALUE, validationDetail.messageKey)
+
     }
 
     @Test
     fun `test validation error if cdr-api host and-or scope and-or tenant are from different environments`() {
-        fail("todo")
+        val config = createCdrClientConfig(blueSkyConnectors()).run {
+            copy(
+                cdrApi = cdrApi.copy(
+                    // tenant id and scope are for localhost -> mismatch with cdr api endpoint
+                    host = Host(ApiEndpoint.PRODUCTION.host),
+                    port = ApiEndpoint.PRODUCTION.port,
+                    scheme = ApiEndpoint.PRODUCTION.protocol
+                )
+            )
+        }
+        val service = ConfigValidationService(config)
+        val result = service.validateAllConfigurationItems(config.toDto())
+
+        assertInstanceOf<DTOs.ValidationResult.Failure>(result)
+        assertEquals(1, result.validationDetails.size)
+
+        val validationDetail = result.validationDetails.first()
+        assertInstanceOf<DTOs.ValidationDetail.ConfigItemDetail>(validationDetail)
+        assertEquals(DomainObjects.ConfigurationItem.CDR_API_HOST, validationDetail.configItem)
+        assertEquals(DTOs.ValidationMessageKey.ILLEGAL_VALUE_COMBINATION, validationDetail.messageKey)
     }
 
     private fun createCdrClientConfig(customers: List<Connector>, defaultLocalFolder: Path = localFolder0): CdrClientConfig =

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/PollingPushFileHandlingTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/PollingPushFileHandlingTest.kt
@@ -4,6 +4,7 @@ import com.mayakapps.kache.ObjectKache
 import com.ninjasquad.springmockk.SpykBean
 import com.swisscom.health.des.cdr.client.AlwaysSameTempDirFactory
 import com.swisscom.health.des.cdr.client.common.Constants.RESTART_FILE_EXTENSION
+import com.swisscom.health.des.cdr.client.common.DomainObjects
 import com.swisscom.health.des.cdr.client.config.CdrApi
 import com.swisscom.health.des.cdr.client.config.CdrClientConfig
 import com.swisscom.health.des.cdr.client.config.ClientId
@@ -108,7 +109,7 @@ internal class PollingPushFileHandlingTest {
         every { config.localFolder } returns TempDownloadDir(inflightDir)
         // 1st call is made by validator, which expects the port to be set to 87; subsequent calls need to know the actual port
         every { config.cdrApi } returns CdrApi(
-            host = Host(cdrServiceMock.hostName),
+            host = Host("localhost"),
             basePath = "documents",
             scheme = "http",
             port = 87,
@@ -119,10 +120,10 @@ internal class PollingPushFileHandlingTest {
             port = cdrServiceMock.port,
         )
         every { config.idpCredentials } returns IdpCredentials(
-            tenantId = TenantId("fake-tenant-id"),
+            tenantId = TenantId(DomainObjects.TenantId.LOCALHOST.tenantId),
             clientId = ClientId("test-client-id"),
             clientSecret = ClientSecret("test-client-secret"),
-            scope = Scope("https://dev.identity.health.swisscom.ch/CdrApi/.default"),
+            scope = Scope(DomainObjects.OAuthScope.LOCALHOST.scope),
             renewCredential = RenewCredential(false),
             maxCredentialAge = Duration.ofDays(365),
             lastCredentialRenewalTime = LastCredentialRenewalTime(Instant.now()),

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/http/WebOperationsTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/http/WebOperationsTest.kt
@@ -3,6 +3,7 @@ package com.swisscom.health.des.cdr.client.http
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.swisscom.health.des.cdr.client.common.Constants.EMPTY_STRING
 import com.swisscom.health.des.cdr.client.common.DTOs
+import com.swisscom.health.des.cdr.client.common.DomainObjects
 import com.swisscom.health.des.cdr.client.config.CdrApi
 import com.swisscom.health.des.cdr.client.config.CdrClientConfig
 import com.swisscom.health.des.cdr.client.config.ClientId
@@ -279,10 +280,10 @@ internal class WebOperationsTest {
         )
 
         val idpCredentials = DTOs.CdrClientConfig.IdpCredentials(
-            tenantId = "test-tenant-id",
+            tenantId = DomainObjects.TenantId.LOCALHOST,
             clientId = "test-client-id",
             clientSecret = "test-client-secret",
-            scope = "scope",
+            scope = DomainObjects.OAuthScope.LOCALHOST,
             renewCredential = true,
             maxCredentialAge = Duration.ofDays(1L),
             lastCredentialRenewalTime = Instant.now()
@@ -319,10 +320,10 @@ internal class WebOperationsTest {
         )
 
         val idpCredentials = DTOs.CdrClientConfig.IdpCredentials(
-            tenantId = "test-tenant-id",
+            tenantId = DomainObjects.TenantId.LOCALHOST,
             clientId = "test-client-id",
             clientSecret = "test-client-secret",
-            scope = "scope",
+            scope = DomainObjects.OAuthScope.LOCALHOST,
             renewCredential = true,
             maxCredentialAge = Duration.ofDays(1L),
             lastCredentialRenewalTime = Instant.now()
@@ -354,10 +355,10 @@ internal class WebOperationsTest {
         )
 
         val idpCredentialsWithMaskedSecret = DTOs.CdrClientConfig.IdpCredentials(
-            tenantId = DEFAULT_CDR_CONFIG.idpCredentials.tenantId.id,
+            tenantId = DomainObjects.TenantId.fromTenantId(DEFAULT_CDR_CONFIG.idpCredentials.tenantId.id),
             clientId = DEFAULT_CDR_CONFIG.idpCredentials.clientId.id,
             clientSecret = ClientSecret.MASKED_SECRET.value,
-            scope = DEFAULT_CDR_CONFIG.idpCredentials.scope.scope,
+            scope = DomainObjects.OAuthScope.fromScope(DEFAULT_CDR_CONFIG.idpCredentials.scope.scope),
             renewCredential = true,
             maxCredentialAge = Duration.ofDays(1L),
             lastCredentialRenewalTime = Instant.now()
@@ -387,10 +388,10 @@ internal class WebOperationsTest {
         )
 
         val idpCredentialsWithAnyMaskedSecret = DTOs.CdrClientConfig.IdpCredentials(
-            tenantId = DEFAULT_CDR_CONFIG.idpCredentials.tenantId.id,
+            tenantId = DomainObjects.TenantId.fromTenantId(DEFAULT_CDR_CONFIG.idpCredentials.tenantId.id),
             clientId = DEFAULT_CDR_CONFIG.idpCredentials.clientId.id,
             clientSecret = "**", // only 2 asterisks — still all-asterisk
-            scope = DEFAULT_CDR_CONFIG.idpCredentials.scope.scope,
+            scope = DomainObjects.OAuthScope.fromScope(DEFAULT_CDR_CONFIG.idpCredentials.scope.scope),
             renewCredential = true,
             maxCredentialAge = Duration.ofDays(1L),
             lastCredentialRenewalTime = Instant.now()
@@ -421,10 +422,10 @@ internal class WebOperationsTest {
 
         val newSecret = "brand-new-secret-entered-by-user"
         val idpCredentialsWithRealSecret = DTOs.CdrClientConfig.IdpCredentials(
-            tenantId = DEFAULT_CDR_CONFIG.idpCredentials.tenantId.id,
+            tenantId = DomainObjects.TenantId.fromTenantId(DEFAULT_CDR_CONFIG.idpCredentials.tenantId.id),
             clientId = DEFAULT_CDR_CONFIG.idpCredentials.clientId.id,
             clientSecret = newSecret,
-            scope = DEFAULT_CDR_CONFIG.idpCredentials.scope.scope,
+            scope = DomainObjects.OAuthScope.fromScope(DEFAULT_CDR_CONFIG.idpCredentials.scope.scope),
             renewCredential = true,
             maxCredentialAge = Duration.ofDays(1L),
             lastCredentialRenewalTime = Instant.now()
@@ -464,10 +465,10 @@ internal class WebOperationsTest {
         )
 
         val idpCredentials = DTOs.CdrClientConfig.IdpCredentials(
-            tenantId = "different-tenant-id",
+            tenantId = DomainObjects.TenantId.STAGING,
             clientId = "test-client-id",
             clientSecret = "test-client-secret",
-            scope = "scope",
+            scope = DomainObjects.OAuthScope.STAGING,
             renewCredential = true,
             maxCredentialAge = Duration.ofDays(1L),
             lastCredentialRenewalTime = Instant.now()
@@ -481,7 +482,7 @@ internal class WebOperationsTest {
         assertEquals(HttpStatus.OK, response.statusCode)
         val validationResult = assertInstanceOf<DTOs.ValidationResult>(response.body)
         assertEquals(DTOs.ValidationResult.Success, validationResult)
-        assertEquals(configWithOriginalEndpoint.idpEndpoint.path.replace("original-tenant-id", idpCredentials.tenantId), idpEndpointSlot.captured.path)
+        assertEquals(configWithOriginalEndpoint.idpEndpoint.path.replace("original-tenant-id", idpCredentials.tenantId.tenantId), idpEndpointSlot.captured.path)
     }
 
     companion object {
@@ -514,10 +515,10 @@ internal class WebOperationsTest {
             ),
             filesInProgressCacheSize = DataSize.ofMegabytes(1L),
             idpCredentials = IdpCredentials(
-                tenantId = TenantId("fake-tenant-id"),
+                tenantId = TenantId(DomainObjects.TenantId.LOCALHOST.tenantId),
                 clientId = ClientId("fake-client-id"),
                 clientSecret = ClientSecret("fake-client-secret"),
-                scope = Scope("scope1"),
+                scope = Scope(DomainObjects.OAuthScope.LOCALHOST.scope),
                 renewCredential = RenewCredential.ENABLED,
                 maxCredentialAge = Duration.ofDays(30),
                 lastCredentialRenewalTime = LastCredentialRenewalTime(Instant.now()),

--- a/cdr-client-service/src/test/resources/application-test.yaml
+++ b/cdr-client-service/src/test/resources/application-test.yaml
@@ -7,7 +7,7 @@ client:
     client-id: easy-system-test-user-id
     client-secret: test-client-secret
     last-credential-renewal-time: 1970-01-01T00:00:00Z
-    scope: https://dev.identity.health.swisscom.ch/CdrApi/.default
+    scope: https://localhost/CdrApi/.default
   idp-endpoint: http://localhost:80/${client.idp-credentials.tenant-id}/oauth2/v2.0/token
   proxy-config:
     url:

--- a/cdr-client-ui/src/commonMain/composeResources/values/strings.xml
+++ b/cdr-client-ui/src/commonMain/composeResources/values/strings.xml
@@ -84,6 +84,7 @@
     <!-- Tooltips -->
 
     <!-- Error messages -->
+    <string name="error_client_internal_error">An internal error occurred in the client. Details:\n%1$s</string>
     <string name="error_client_communication">Failed to communicate with the client service. Details:\n%1$s</string>
     <string name="error_client_configuration">There is an error in your config. Check the UI for remarks</string>
     <string name="error_client_validation">curaLINE client reported an error. Details:\n%1$s</string>
@@ -108,4 +109,5 @@
     <string name="error_proxy_url_must_start_with_http_or_https">Proxy URL must start with http:// or https://</string>
     <string name="error_proxy_url_invalid_format">Invalid proxy URL format</string>
     <string name="error_illegal_value">Value is not valid/can't be used here</string>
+    <string name="error_illegal_value_combination">The combination of values is not valid</string>
 </resources>

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/CdrConfigScreen.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/CdrConfigScreen.kt
@@ -39,6 +39,7 @@ import com.swisscom.health.des.cdr.client.common.DTOs
 import com.swisscom.health.des.cdr.client.common.DomainObjects
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.Res
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.Swisscom_Lifeform_RGB_Colour_icon
+import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_client_internal_error
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_apply
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_cdr_api_host
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_cdr_api_host_placeholder
@@ -62,8 +63,6 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 private val logger = KotlinLogging.logger {}
-private const val SCOPE_STAGING = "https://tst.identity.health.swisscom.ch/CdrApi/.default"
-private const val SCOPE_PRODUCTION = "https://identity.health.swisscom.ch/CdrApi/.default"
 
 @Composable
 internal fun CdrConfigScreen(
@@ -163,10 +162,20 @@ internal fun CdrConfigScreen(
                     if (canEdit) {
                         DomainObjects.ApiEndpoint.valueOf(it).also { apiEndpoint ->
                             viewModel.setCdrApiEndpoint(apiEndpoint)
-                            if (apiEndpoint == DomainObjects.ApiEndpoint.STAGING) {
-                                viewModel.setIdpCredentialsScope(SCOPE_STAGING)
-                            } else {
-                                viewModel.setIdpCredentialsScope(SCOPE_PRODUCTION)
+                            when (apiEndpoint) {
+                                DomainObjects.ApiEndpoint.PRODUCTION -> {
+                                    viewModel.setIdpCredentialsScope(DomainObjects.OAuthScope.PRODUCTION)
+                                    viewModel.setIdpTenantId(DomainObjects.TenantId.PRODUCTION)
+                                }
+
+                                DomainObjects.ApiEndpoint.STAGING -> {
+                                    viewModel.setIdpCredentialsScope(DomainObjects.OAuthScope.STAGING)
+                                    viewModel.setIdpTenantId(DomainObjects.TenantId.STAGING)
+                                }
+
+                                else -> {
+                                    viewModel.reportError(Res.string.error_client_internal_error, "Unknown API endpoint '$apiEndpoint'")
+                                }
                             }
                         }
                     }

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/CdrConfigViewModel.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/CdrConfigViewModel.kt
@@ -228,7 +228,7 @@ internal class CdrConfigViewModel(
         }
     }
 
-    fun setIdpCredentialsScope(scope: String) {
+    fun setIdpCredentialsScope(scope: DomainObjects.OAuthScope) {
         logger.debug { "setIdpCredentialsScope" }
         _uiState.update {
             it.copy(
@@ -262,7 +262,7 @@ internal class CdrConfigViewModel(
      *
      * @param id The IDP tenant ID to use.
      */
-    fun setIdpTenantId(id: String) {
+    fun setIdpTenantId(id: DomainObjects.TenantId) {
         logger.debug { "setTenantId: '$id'" }
         _uiState.update {
             it.copy(

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/ComposeUtils.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/ComposeUtils.kt
@@ -55,6 +55,7 @@ import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.e
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_folder_overlaps_non_error
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_illegal_mode
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_illegal_value
+import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_illegal_value_combination
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_is_credentials
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_is_placeholder
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.error_no_connector
@@ -116,6 +117,7 @@ internal val DTOs.ValidationMessageKey.stringResource: StringResource
             DTOs.ValidationMessageKey.PROXY_URL_MUST_START_WITH_HTTP_OR_HTTPS -> Res.string.error_proxy_url_must_start_with_http_or_https
             DTOs.ValidationMessageKey.PROXY_URL_INVALID_FORMAT -> Res.string.error_proxy_url_invalid_format
             DTOs.ValidationMessageKey.ILLEGAL_VALUE -> Res.string.error_illegal_value
+            DTOs.ValidationMessageKey.ILLEGAL_VALUE_COMBINATION -> Res.string.error_illegal_value_combination
         }
 
 @Composable

--- a/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/IdpSettingsGroup.kt
+++ b/cdr-client-ui/src/commonMain/kotlin/com/swisscom/health/des/cdr/client/ui/IdpSettingsGroup.kt
@@ -21,8 +21,6 @@ import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.l
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_client_idp_settings_client_id_placeholder
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_client_idp_settings_client_secret
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_client_idp_settings_client_secret_placeholder
-import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_client_idp_settings_tenant_id
-import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_client_idp_settings_tenant_id_placeholder
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_validate
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.label_validate_idp_credentials_info
 import com.swisscom.health.des.cdr.client.ui.cdr_client_ui.generated.resources.message_loading_initial_config
@@ -53,23 +51,6 @@ internal fun IdpSettingsGroup(
             Text(text = stringResource(Res.string.message_loading_initial_config))
             Divider(modifier = modifier.padding(bottom = 8.dp))
         } else {
-            // Tenant ID
-            var tenantIdValidationResult: DTOs.ValidationResult by remember { mutableStateOf(DTOs.ValidationResult.Success) }
-            LaunchedEffect(uiState.clientServiceConfig.idpCredentials.tenantId) {
-                tenantIdValidationResult =
-                    remoteViewValidations.validateNotBlank(uiState.clientServiceConfig.idpCredentials.tenantId, DomainObjects.ConfigurationItem.IDP_TENANT_ID)
-            }
-            ValidatedTextField(
-                name = DomainObjects.ConfigurationItem.IDP_TENANT_ID,
-                modifier = modifier.fillMaxWidth(),
-                validatable = { tenantIdValidationResult },
-                label = { Text(text = stringResource(Res.string.label_client_idp_settings_tenant_id)) },
-                placeHolder = { Text(text = stringResource(Res.string.label_client_idp_settings_tenant_id_placeholder)) },
-                value = uiState.clientServiceConfig.idpCredentials.tenantId,
-                onValueChange = { if (canEdit) viewModel.setIdpTenantId(it) },
-                enabled = canEdit,
-            )
-
             // Client ID
             var clientIdValidationResult: DTOs.ValidationResult by remember { mutableStateOf(DTOs.ValidationResult.Success) }
             LaunchedEffect(uiState.clientServiceConfig.idpCredentials.clientId) {


### PR DESCRIPTION
…, tenant, and scope are validated to be consistent for a particular environment (prod, stage, localhost)