### PR TITLE
#47108 treat a response status code 409 for a document upload as a "d…

### DIFF
--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/CdrApiClient.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/CdrApiClient.kt
@@ -38,7 +38,7 @@ internal class CdrApiClient(
     @param:Qualifier("retryIoAndServerErrors")
     private val retryIOExceptionsAndServerErrors: RetryTemplate,
     private val objectMapper: ObjectMapper,
-    private val osInformation: String
+    private val osInformation: String,
 ) {
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -154,7 +154,7 @@ internal class CdrApiClient(
      * @param traceId the trace id to propagate upstream for log correlation
      * @return the result of the HTTP post translated into a [UploadDocumentResult]
      */
-    @Suppress("MagicNumber")
+    @Suppress("MagicNumber", "CyclomaticComplexMethod")
     fun uploadDocument(contentType: String, file: Path, connectorId: String, mode: CdrClientConfig.Mode, traceId: String): UploadDocumentResult =
         runCatching {
             logger.debug { "Upload '$file' start" }
@@ -171,6 +171,13 @@ internal class CdrApiClient(
                     when {
                         response.isSuccessful -> UploadDocumentResult.Success.also { _ ->
                             logger.debug { "Upload '$file' done" }
+                        }
+
+                        response.code == HttpStatus.CONFLICT.value() -> UploadDocumentResult.Success.also { _ ->
+                            logger.info {
+                                "Upload of '$file' failed with status code '${HttpStatus.CONFLICT}'; " +
+                                        "upload will be treated as a success, as a another copy of the document has already been uploaded."
+                            }
                         }
 
                         response.code == HttpStatus.BAD_REQUEST.value() -> UploadDocumentResult.UploadClientErrorResponse(

--- a/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/RetryUploadFileHandling.kt
+++ b/cdr-client-service/src/main/kotlin/com/swisscom/health/des/cdr/client/handler/RetryUploadFileHandling.kt
@@ -79,7 +79,7 @@ internal class RetryUploadFileHandling(
 
                     is UploadDocumentResult.UploadClientRetryableErrorResponse -> {
                         logger.error {
-                            "File synchronization failed for '${uploadFile.fileName}'. Received a 4xx client error (response code: '${response.code}'). " +
+                            "File synchronization failed for '${uploadFile.fileName}'. Received a client error (response code: '${response.code}'). " +
                                     "Retry will be attempted in '${cdrClientConfig.retryDelay[retryIndex]}'"
                         }
                         true
@@ -87,7 +87,7 @@ internal class RetryUploadFileHandling(
 
                     is UploadDocumentResult.UploadClientConfigNonRetryableErrorResponse -> {
                         logger.error {
-                            "File synchronization failed for '${uploadFile.fileName}'. Received a 4xx client error (response code: '${response.code}'). " +
+                            "File synchronization failed for '${uploadFile.fileName}'. Received a client error (response code: '${response.code}'). " +
                                     "The file extension will be modified and it will be retried after the next restart."
                         }
                         renameFileToFail(uploadFile)
@@ -96,7 +96,7 @@ internal class RetryUploadFileHandling(
 
                     is UploadDocumentResult.UploadClientErrorResponse -> {
                         logger.error {
-                            "File synchronization failed for '${uploadFile.fileName}'. Received a 4xx client error (response code: '${response.code}'). " +
+                            "File synchronization failed for '${uploadFile.fileName}'. Received a client error (response code: '${response.code}'). " +
                                     "No retry will be attempted and the file will be moved to the error directory due to client-side issue."
                         }
                         renameFileToErrorAndCreateLogFile(uploadFile, response.responseBody)
@@ -105,16 +105,16 @@ internal class RetryUploadFileHandling(
 
                     is UploadDocumentResult.UploadServerErrorResponse -> {
                         logger.error {
-                            "Failed to sync file '${uploadFile.fileName}', retry will be attempted in '${cdrClientConfig.retryDelay[retryIndex]}' - " +
-                                    "server response: '${response.responseBody}'"
+                            "File synchronization failed for '${uploadFile.fileName}'. Received a client error (response code: '${response.code}'). " +
+                                    "Retry will be attempted in '${cdrClientConfig.retryDelay[retryIndex]}' - server response:\n'${response.responseBody}'"
                         }
                         true
                     }
 
                     is UploadDocumentResult.UploadError -> {
                         logger.error {
-                            "Failed to sync file '${uploadFile.fileName}', retry will be attempted in '${cdrClientConfig.retryDelay[retryIndex]}' - " +
-                                    "exception message: '${response.t?.message}'"
+                            "File synchronization failed for '${uploadFile.fileName}'. No server response is available. " +
+                                    "Retry will be attempted in '${cdrClientConfig.retryDelay[retryIndex]}' - exception message: '${response.t?.message}'"
                         }
                         true
                     }

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/CdrApiClientTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/CdrApiClientTest.kt
@@ -1,5 +1,6 @@
 package com.swisscom.health.des.cdr.client.handler
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.SpykBean
 import com.swisscom.health.des.cdr.client.AlwaysSameTempDirFactory
 import com.swisscom.health.des.cdr.client.common.Constants.EMPTY_STRING
@@ -25,11 +26,14 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.annotation.DirtiesContext.ClassMode
 import org.springframework.test.context.ActiveProfiles
@@ -63,6 +67,9 @@ internal class CdrApiClientTest {
 
     @Autowired
     private lateinit var cdrApiClient: CdrApiClient
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
 
     @TempDir
     private lateinit var sourceDir: Path
@@ -167,10 +174,15 @@ internal class CdrApiClientTest {
         assertEquals(4, apiServerMock.requestCount)
     }
 
-    @Test
-    fun `test document upload - status 202`() {
+    @ParameterizedTest
+    @CsvSource(
+        "200",
+        "201",
+        "202",
+    )
+    fun `test document upload - status 2xx`(successStatus: Int) {
         val mockResponse = MockResponse.Builder()
-            .code(HttpStatus.ACCEPTED.value())
+            .code(successStatus)
             .headers(Headers.Builder().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).build())
             .body("""{"message": "Upload successful"}""")
             .build()
@@ -198,6 +210,36 @@ internal class CdrApiClientTest {
         assertTrue(requireNotNull(request.headers[HttpHeaders.AUTHORIZATION]).startsWith("Bearer "))
         assertTrue(requireNotNull(request.headers[HttpHeaders.AUTHORIZATION]).removePrefix("Bearer ").isNotBlank())
 
+        assertEquals(1, apiServerMock.requestCount)
+    }
+
+    @Test
+    fun `test document upload - status 409`() {
+        val problemJsonStr = objectMapper.writeValueAsString(
+            ProblemDetail.forStatus(HttpStatus.CONFLICT.value())
+                .run {
+                    title = HttpStatus.CONFLICT.reasonPhrase
+                }
+        )
+        val mockResponse = MockResponse.Builder()
+            .code(HttpStatus.CONFLICT.value())
+            .headers(Headers.Builder().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PROBLEM_JSON_VALUE).build())
+            .body(problemJsonStr)
+            .build()
+        apiServerMock.enqueue(mockResponse)
+
+        val testFile: Path = sourceDir.resolve("test-file.txt").apply { writeText("test content") }
+
+        val result: CdrApiClient.UploadDocumentResult = cdrApiClient.uploadDocument(
+            contentType = "application/forumdatenaustausch+xml;charset=UTF-8",
+            file = testFile,
+            connectorId = "test-connector-id",
+            mode = CdrClientConfig.Mode.TEST,
+            traceId = DEFAULT_TRACE_ID
+        )
+
+        // 409 is a "derived success" as the status code implies that the document has successfully been uploaded in a previous attempt
+        assertInstanceOf<CdrApiClient.UploadDocumentResult.Success>(result) { "CdrApiClient.UploadDocumentResult.Success expected but got $result" }
         assertEquals(1, apiServerMock.requestCount)
     }
 

--- a/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/PollingPushFileHandlingTest.kt
+++ b/cdr-client-service/src/test/kotlin/com/swisscom/health/des/cdr/client/handler/PollingPushFileHandlingTest.kt
@@ -444,7 +444,7 @@ internal class PollingPushFileHandlingTest {
     }
 
     @Test
-    fun `test successfully write two files to API fail with third CONFLICT - no separate error directory, rename file`() {
+    fun `test successfully write two files to API fail with third TEAPOT - no separate error directory, rename file`() {
         val mockResponse = MockResponse.Builder()
             .code(HttpStatus.OK.value())
             .headers(Headers.Builder().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).build())
@@ -455,7 +455,7 @@ internal class PollingPushFileHandlingTest {
         cdrServiceMock.enqueue(MockResponse.Builder().code(HttpStatus.INTERNAL_SERVER_ERROR.value()).body("{\"message\": \"Exception\"}").build())
         cdrServiceMock.enqueue(MockResponse.Builder().code(HttpStatus.INTERNAL_SERVER_ERROR.value()).body("{\"message\": \"Exception\"}").build())
         cdrServiceMock.enqueue(MockResponse.Builder().code(HttpStatus.INTERNAL_SERVER_ERROR.value()).body("{\"message\": \"Exception\"}").build())
-        cdrServiceMock.enqueue(MockResponse.Builder().code(HttpStatus.CONFLICT.value()).body("{\"message\": \"Exception\"}").build())
+        cdrServiceMock.enqueue(MockResponse.Builder().code(HttpStatus.I_AM_A_TEAPOT.value()).body("{\"message\": \"Exception\"}").build())
 
         val sourceDir = tmpDir.resolve(sourceDirectory)
 


### PR DESCRIPTION
…erived success" as a previous attempt to upload that same document must have succeeded